### PR TITLE
Benyttes servicebruker sin token ved registerkall

### DIFF
--- a/nais.yaml
+++ b/nais.yaml
@@ -36,6 +36,7 @@ fasitResources:
   - alias: eessi-pensjon-active-profiles
     resourceType: ApplicationProperties
 
+  #PESYS
   - alias: Pensjonsinformasjon
     resourceType: RestService
 
@@ -54,17 +55,17 @@ fasitResources:
   - alias: OpenIdConnect
     resourceType: BaseUrl
 
-#    Denne brukes av nye rest tjenester
+  #Brukes av nye rest tjenester
   - alias: security-token-service-token
     resourceType: RestService
 
-    #     nye rest tjeneste config
-  - alias: security-token-service-openid-configuration
-    resourceType: RestService
-
-#    Denne brukes av gamle tjenester
+  #Brukes av gamle tjenester
   - alias: securityTokenService
     resourceType: BaseUrl
+
+  #Brukes av Loginservice
+  - alias: security-token-service-openid-configuration
+    resourceType: RestService
 
   exposed:
   - alias: eessifagmodulservice

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/services/aktoerregister/AktoerregisterRestTemplate.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/services/aktoerregister/AktoerregisterRestTemplate.kt
@@ -1,8 +1,8 @@
 package no.nav.eessi.eessifagmodul.services.aktoerregister
 
 import io.micrometer.core.instrument.MeterRegistry
-import no.nav.eessi.eessifagmodul.config.OidcAuthorizationHeaderInterceptor
-import no.nav.security.oidc.context.OIDCRequestContextHolder
+import no.nav.eessi.eessifagmodul.services.sts.SecurityTokenExchangeService
+import no.nav.eessi.eessifagmodul.services.sts.UsernameToOidcInterceptor
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.actuate.metrics.web.client.DefaultRestTemplateExchangeTagsProvider
 import org.springframework.boot.actuate.metrics.web.client.MetricsRestTemplateCustomizer
@@ -15,7 +15,8 @@ import org.springframework.web.client.DefaultResponseErrorHandler
 import org.springframework.web.client.RestTemplate
 
 @Component
-class AktoerregisterRestTemplate(val oidcRequestContextHolder: OIDCRequestContextHolder, val registry: MeterRegistry) {
+class AktoerregisterRestTemplate(val securityTokenExchangeService: SecurityTokenExchangeService,
+                                 val registry: MeterRegistry) {
 
     @Value("\${aktoerregister.api.v1.url}")
     lateinit var url: String
@@ -25,7 +26,7 @@ class AktoerregisterRestTemplate(val oidcRequestContextHolder: OIDCRequestContex
         return templateBuilder
                 .rootUri(url)
                 .errorHandler(DefaultResponseErrorHandler())
-                .additionalInterceptors(OidcAuthorizationHeaderInterceptor(oidcRequestContextHolder))
+                .additionalInterceptors(UsernameToOidcInterceptor(securityTokenExchangeService))
                 .customizers(MetricsRestTemplateCustomizer(registry, DefaultRestTemplateExchangeTagsProvider(), "eessipensjon_fagmodul_aktoer"))
                 .build().apply {
                     requestFactory = BufferingClientHttpRequestFactory(SimpleClientHttpRequestFactory())

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/services/sts/OnBehalfOfOutInterceptor.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/services/sts/OnBehalfOfOutInterceptor.kt
@@ -1,4 +1,4 @@
-package no.nav.eessi.eessifagmodul.config.sts
+package no.nav.eessi.eessifagmodul.services.sts
 
 /**
  * Documentation at https://confluence.adeo.no/display/KES/STS+-+Brukerdokumentasjon

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/services/sts/STSDatapowerClientConfig.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/services/sts/STSDatapowerClientConfig.kt
@@ -1,4 +1,4 @@
-package no.nav.eessi.eessifagmodul.config.sts
+package no.nav.eessi.eessifagmodul.services.sts
 
 /**
  * Documentation at https://confluence.adeo.no/display/KES/STS+-+Brukerdokumentasjon

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/services/sts/STSRestTemplate.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/services/sts/STSRestTemplate.kt
@@ -1,4 +1,4 @@
-package no.nav.eessi.eessifagmodul.config.securitytokenexchange
+package no.nav.eessi.eessifagmodul.services.sts
 
 import no.nav.eessi.eessifagmodul.config.RequestResponseLoggerInterceptor
 import org.slf4j.LoggerFactory
@@ -11,10 +11,14 @@ import org.springframework.http.client.support.BasicAuthenticationInterceptor
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
 
+/**
+ * STS rest template for å hente OIDCtoken for nye tjenester
+ *
+ */
 @Component
-class SecurityTokenExchangeRestTemplate {
+class STSRestTemplate {
 
-    private val logger = LoggerFactory.getLogger(SecurityTokenExchangeRestTemplate::class.java)
+    private val logger = LoggerFactory.getLogger(STSRestTemplate::class.java)
 
     @Value("\${security-token-service-token.url}")
     lateinit var baseUrl: String

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/services/sts/STSService.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/services/sts/STSService.kt
@@ -1,4 +1,4 @@
-package no.nav.eessi.eessifagmodul.config.securitytokenexchange
+package no.nav.eessi.eessifagmodul.services.sts
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -51,8 +51,12 @@ class SecurityTokenExchangeService(val securityTokenExchangeBasicAuthRestTemplat
                     .queryParam("scope", "openid")
                     .build().toUriString()
 
-            logger.info("kobler opp mot systembruker token")
-            val responseEntity = securityTokenExchangeBasicAuthRestTemplate.exchange(uri, HttpMethod.GET, null, typeRef<SecurityTokenResponse>())
+            logger.info("Kaller STS for å bytte username/password til OIDC token")
+            val responseEntity = securityTokenExchangeBasicAuthRestTemplate.exchange(uri,
+                    HttpMethod.GET,
+                    null,
+                    typeRef<SecurityTokenResponse>())
+
             logger.debug("SecurityTokenResponse ${mapAnyToJson(responseEntity)} ")
             validateResponse(responseEntity)
             val accessToken = responseEntity.body!!.accessToken
@@ -65,7 +69,7 @@ class SecurityTokenExchangeService(val securityTokenExchangeBasicAuthRestTemplat
             logger.debug("Added token to cache, expires in $expiresInSeconds seconds")
             return accessToken
         } catch (ex: Exception) {
-            logger.error("Feil ved tildeling av token til Systembruker: ${ex.message}", ex)
+            logger.error("Feil ved bytting av username/password til OIDC token: ${ex.message}", ex)
             throw SystembrukerTokenException(ex.message!!)
         }
     }

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/services/sts/UsernameToOidcInterceptor.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/services/sts/UsernameToOidcInterceptor.kt
@@ -1,4 +1,4 @@
-package no.nav.eessi.eessifagmodul.config.securitytokenexchange
+package no.nav.eessi.eessifagmodul.services.sts
 
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpRequest
@@ -7,7 +7,7 @@ import org.springframework.http.client.ClientHttpRequestInterceptor
 import org.springframework.http.client.ClientHttpResponse
 
 
-class UntToOidcInterceptor(private val securityTokenExchangeService: SecurityTokenExchangeService) : ClientHttpRequestInterceptor {
+class UsernameToOidcInterceptor(private val securityTokenExchangeService: SecurityTokenExchangeService) : ClientHttpRequestInterceptor {
 
     override fun intercept(request: HttpRequest, body: ByteArray, execution: ClientHttpRequestExecution): ClientHttpResponse {
         val token = securityTokenExchangeService.getSystemOidcToken()


### PR DESCRIPTION
Til nå har vi benyttet den innloggede brukerens oidcToken for å gjøre kall mot nav registre.
Det fungerer ikke i alle tilfeller da vi må switche mellom to STSer

Denne kodeendringen fører til at hvert kall benytter sin spesifike STS klient