### PR TITLE
Move Controllers to domain packages

### DIFF
--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/arkiv/SafController.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/arkiv/SafController.kt
@@ -1,4 +1,4 @@
-package no.nav.eessi.eessifagmodul.controllers
+package no.nav.eessi.eessifagmodul.arkiv
 
 import io.swagger.annotations.ApiOperation
 import no.nav.eessi.eessifagmodul.services.saf.SafService
@@ -7,7 +7,10 @@ import no.nav.security.oidc.api.Protected
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 import java.util.*
 
 @Protected

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/eux/BucController.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/eux/BucController.kt
@@ -1,6 +1,7 @@
-package no.nav.eessi.eessifagmodul.controllers
+package no.nav.eessi.eessifagmodul.eux
 
 import io.swagger.annotations.ApiOperation
+import no.nav.eessi.eessifagmodul.person.AktoerIdHelper
 import no.nav.eessi.eessifagmodul.models.InstitusjonItem
 import no.nav.eessi.eessifagmodul.models.Krav
 import no.nav.eessi.eessifagmodul.services.aktoerregister.AktoerregisterService

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/eux/SedController.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/eux/SedController.kt
@@ -1,7 +1,8 @@
-package no.nav.eessi.eessifagmodul.controllers
+package no.nav.eessi.eessifagmodul.eux
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.annotations.ApiOperation
+import no.nav.eessi.eessifagmodul.person.AktoerIdHelper
 import no.nav.eessi.eessifagmodul.models.IkkeGyldigKallException
 import no.nav.eessi.eessifagmodul.models.InstitusjonItem
 import no.nav.eessi.eessifagmodul.models.SED

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/geo/LandkodeController.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/geo/LandkodeController.kt
@@ -1,4 +1,4 @@
-package no.nav.eessi.eessifagmodul.controllers
+package no.nav.eessi.eessifagmodul.geo
 
 import io.swagger.annotations.ApiOperation
 import no.nav.eessi.eessifagmodul.services.LandkodeService

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/geo/PostkodeController.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/geo/PostkodeController.kt
@@ -1,4 +1,4 @@
-package no.nav.eessi.eessifagmodul.controllers
+package no.nav.eessi.eessifagmodul.geo
 
 import io.swagger.annotations.ApiOperation
 import no.nav.eessi.eessifagmodul.services.PostnummerService

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/health/DiagnosticsController.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/health/DiagnosticsController.kt
@@ -1,11 +1,11 @@
 package no.nav.eessi.eessifagmodul.health
 
+import no.nav.eessi.eessifagmodul.metrics.getCounter
 import no.nav.eessi.eessifagmodul.models.IkkeGyldigKallException
 import no.nav.eessi.eessifagmodul.services.eux.EuxService
 import no.nav.eessi.eessifagmodul.services.pensjonsinformasjon.PensjonsinformasjonService
 import no.nav.eessi.eessifagmodul.services.personv3.PersonV3Service
 import no.nav.eessi.eessifagmodul.services.sts.STSService
-import no.nav.eessi.eessifagmodul.metrics.getCounter
 import no.nav.eessi.eessifagmodul.utils.mapJsonToAny
 import no.nav.eessi.eessifagmodul.utils.typeRefs
 import no.nav.security.oidc.api.Protected

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/pensjon/PensjonController.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/pensjon/PensjonController.kt
@@ -1,4 +1,4 @@
-package no.nav.eessi.eessifagmodul.controllers
+package no.nav.eessi.eessifagmodul.pensjon
 
 import io.swagger.annotations.ApiOperation
 import no.nav.eessi.eessifagmodul.models.AktoerregisterException

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/person/AktoerIdHelper.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/person/AktoerIdHelper.kt
@@ -1,4 +1,4 @@
-package no.nav.eessi.eessifagmodul.controllers
+package no.nav.eessi.eessifagmodul.person
 
 import no.nav.eessi.eessifagmodul.models.AktoerregisterException
 import no.nav.eessi.eessifagmodul.models.IkkeGyldigKallException

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/person/NavRegistreOppslagController.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/person/NavRegistreOppslagController.kt
@@ -1,4 +1,4 @@
-package no.nav.eessi.eessifagmodul.controllers
+package no.nav.eessi.eessifagmodul.person
 
 import io.swagger.annotations.ApiOperation
 import no.nav.eessi.eessifagmodul.models.*
@@ -12,7 +12,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
-private val logger = LoggerFactory.getLogger(PersonController::class.java)
+private val logger = LoggerFactory.getLogger(NavRegistreOppslagController::class.java)
 
 /**
  * Controller for å kalle NAV interne registre
@@ -22,7 +22,7 @@ private val logger = LoggerFactory.getLogger(PersonController::class.java)
  */
 @Protected
 @RestController
-class PersonController(private val aktoerregisterService: AktoerregisterService,
+class NavRegistreOppslagController(private val aktoerregisterService: AktoerregisterService,
                                 private val personService: PersonV3Service) {
 
     /**
@@ -32,8 +32,8 @@ class PersonController(private val aktoerregisterService: AktoerregisterService,
      * @param aktoerid
      */
     @ApiOperation("henter ut personinformasjon for en aktørId")
-    @GetMapping("/person/{aktoerid}")
-    fun getDocument(@PathVariable("aktoerid", required = true) aktoerid: String): ResponseEntity<HentPersonResponse> {
+    @GetMapping("/personinfo/{aktoerid}")
+    fun getDocument(@PathVariable("aktoerid", required = true) aktoerid: String): ResponseEntity<Personinformasjon> {
         logger.info("Henter personinformasjon for aktørId")
 
         val norskIdent: String
@@ -62,6 +62,10 @@ class PersonController(private val aktoerregisterService: AktoerregisterService,
         }
 
         getCounter("PERSONINFORMASJONOK").increment()
-        return ResponseEntity.ok(personresp)
+        return ResponseEntity.ok(Personinformasjon(personresp.person.personnavn.sammensattNavn,
+                personresp.person.personnavn.fornavn,
+                personresp.person.personnavn.mellomnavn,
+                personresp.person.personnavn.etternavn))
     }
 }
+

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/person/PersonController.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/person/PersonController.kt
@@ -1,4 +1,4 @@
-package no.nav.eessi.eessifagmodul.controllers
+package no.nav.eessi.eessifagmodul.person
 
 import io.swagger.annotations.ApiOperation
 import no.nav.eessi.eessifagmodul.models.*
@@ -12,7 +12,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
-private val logger = LoggerFactory.getLogger(NavRegistreOppslagController::class.java)
+private val logger = LoggerFactory.getLogger(PersonController::class.java)
 
 /**
  * Controller for å kalle NAV interne registre
@@ -22,7 +22,7 @@ private val logger = LoggerFactory.getLogger(NavRegistreOppslagController::class
  */
 @Protected
 @RestController
-class NavRegistreOppslagController(private val aktoerregisterService: AktoerregisterService,
+class PersonController(private val aktoerregisterService: AktoerregisterService,
                                 private val personService: PersonV3Service) {
 
     /**
@@ -32,8 +32,8 @@ class NavRegistreOppslagController(private val aktoerregisterService: Aktoerregi
      * @param aktoerid
      */
     @ApiOperation("henter ut personinformasjon for en aktørId")
-    @GetMapping("/personinfo/{aktoerid}")
-    fun getDocument(@PathVariable("aktoerid", required = true) aktoerid: String): ResponseEntity<Personinformasjon> {
+    @GetMapping("/person/{aktoerid}")
+    fun getDocument(@PathVariable("aktoerid", required = true) aktoerid: String): ResponseEntity<HentPersonResponse> {
         logger.info("Henter personinformasjon for aktørId")
 
         val norskIdent: String
@@ -62,10 +62,6 @@ class NavRegistreOppslagController(private val aktoerregisterService: Aktoerregi
         }
 
         getCounter("PERSONINFORMASJONOK").increment()
-        return ResponseEntity.ok(Personinformasjon(personresp.person.personnavn.sammensattNavn,
-                personresp.person.personnavn.fornavn,
-                personresp.person.personnavn.mellomnavn,
-                personresp.person.personnavn.etternavn))
+        return ResponseEntity.ok(personresp)
     }
 }
-

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/eux/ApIRequestTest.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/eux/ApIRequestTest.kt
@@ -1,8 +1,7 @@
-package no.nav.eessi.eessifagmodul.controllers
+package no.nav.eessi.eessifagmodul.eux
 
 import no.nav.eessi.eessifagmodul.models.InstitusjonItem
 import no.nav.eessi.eessifagmodul.models.SED
-import no.nav.eessi.eessifagmodul.services.LandkodeService
 import no.nav.eessi.eessifagmodul.utils.mapAnyToJson
 import no.nav.eessi.eessifagmodul.utils.validateJson
 import org.junit.Test
@@ -18,7 +17,7 @@ class ApIRequestTest {
     private val printout = false
     private val printsed = false
 
-    private val logger: Logger by lazy { LoggerFactory.getLogger(LandkodeService::class.java) }
+    private val logger: Logger by lazy { LoggerFactory.getLogger(ApIRequestTest::class.java) }
 
 
     private fun createMockApiRequest(sedName: String, buc: String, payload: String): SedController.ApiRequest {

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/eux/BucControllerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/eux/BucControllerTest.kt
@@ -1,4 +1,4 @@
-package no.nav.eessi.eessifagmodul.controllers
+package no.nav.eessi.eessifagmodul.eux
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.whenever
@@ -6,17 +6,13 @@ import no.nav.eessi.eessifagmodul.models.*
 import no.nav.eessi.eessifagmodul.services.aktoerregister.AktoerregisterService
 import no.nav.eessi.eessifagmodul.services.eux.BucUtils
 import no.nav.eessi.eessifagmodul.services.eux.EuxService
-import no.nav.eessi.eessifagmodul.services.eux.RinaAksjon
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import java.nio.file.Files
-import java.nio.file.Paths
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 @RunWith(MockitoJUnitRunner.Silent::class)
 class BucControllerTest {

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/eux/SedControllerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/eux/SedControllerTest.kt
@@ -1,4 +1,4 @@
-package no.nav.eessi.eessifagmodul.controllers
+package no.nav.eessi.eessifagmodul.eux
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nhaarman.mockito_kotlin.any
@@ -12,8 +12,6 @@ import no.nav.eessi.eessifagmodul.services.aktoerregister.AktoerregisterService
 import no.nav.eessi.eessifagmodul.services.eux.BucSedResponse
 import no.nav.eessi.eessifagmodul.services.eux.BucUtils
 import no.nav.eessi.eessifagmodul.services.eux.EuxService
-import no.nav.eessi.eessifagmodul.services.eux.bucmodel.Buc
-import no.nav.eessi.eessifagmodul.services.eux.bucmodel.DocumentsItem
 import no.nav.eessi.eessifagmodul.services.eux.bucmodel.ShortDocumentItem
 import org.junit.Before
 import org.junit.Test

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/models/SedP4000Test.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/models/SedP4000Test.kt
@@ -2,7 +2,7 @@ package no.nav.eessi.eessifagmodul.models
 
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.whenever
-import no.nav.eessi.eessifagmodul.controllers.SedController
+import no.nav.eessi.eessifagmodul.eux.SedController
 import no.nav.eessi.eessifagmodul.prefill.PrefillDataModel
 import no.nav.eessi.eessifagmodul.prefill.PrefillP4000
 import no.nav.eessi.eessifagmodul.prefill.PrefillSED

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/pensjon/PensjonControllerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/pensjon/PensjonControllerTest.kt
@@ -1,4 +1,4 @@
-package no.nav.eessi.eessifagmodul.controllers
+package no.nav.eessi.eessifagmodul.pensjon
 
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.mock
@@ -6,6 +6,7 @@ import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import no.nav.eessi.eessifagmodul.models.IkkeFunnetException
 import no.nav.eessi.eessifagmodul.models.PensjoninformasjonException
+import no.nav.eessi.eessifagmodul.pensjon.PensjonController
 import no.nav.eessi.eessifagmodul.services.aktoerregister.AktoerregisterService
 import no.nav.eessi.eessifagmodul.services.pensjonsinformasjon.PensjonsinformasjonService
 import no.nav.eessi.eessifagmodul.services.pensjonsinformasjon.Pensjontype

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/prefill/P7000/PrefillP7000-AP-21975717Test.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/prefill/P7000/PrefillP7000-AP-21975717Test.kt
@@ -1,6 +1,6 @@
 package no.nav.eessi.eessifagmodul.prefill.P7000
 
-import no.nav.eessi.eessifagmodul.controllers.SedController
+import no.nav.eessi.eessifagmodul.eux.SedController
 import no.nav.eessi.eessifagmodul.models.InstitusjonItem
 import no.nav.eessi.eessifagmodul.models.SED
 import no.nav.eessi.eessifagmodul.prefill.*

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/prefill/krav/PrefillP2000-AP-21975717Test.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/prefill/krav/PrefillP2000-AP-21975717Test.kt
@@ -1,6 +1,6 @@
 package no.nav.eessi.eessifagmodul.prefill.krav
 
-import no.nav.eessi.eessifagmodul.controllers.SedController
+import no.nav.eessi.eessifagmodul.eux.SedController
 import no.nav.eessi.eessifagmodul.models.InstitusjonItem
 import no.nav.eessi.eessifagmodul.models.Nav
 import no.nav.eessi.eessifagmodul.models.SED

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/prefill/krav/PrefillP2000-AP-LOP-REVUTest.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/prefill/krav/PrefillP2000-AP-LOP-REVUTest.kt
@@ -1,6 +1,6 @@
 package no.nav.eessi.eessifagmodul.prefill.krav
 
-import no.nav.eessi.eessifagmodul.controllers.SedController
+import no.nav.eessi.eessifagmodul.eux.SedController
 import no.nav.eessi.eessifagmodul.models.InstitusjonItem
 import no.nav.eessi.eessifagmodul.models.Nav
 import no.nav.eessi.eessifagmodul.models.SED

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/prefill/krav/PrefillP2000-AP-LOP-UTLANDTest.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/prefill/krav/PrefillP2000-AP-LOP-UTLANDTest.kt
@@ -1,6 +1,6 @@
 package no.nav.eessi.eessifagmodul.prefill.krav
 
-import no.nav.eessi.eessifagmodul.controllers.SedController
+import no.nav.eessi.eessifagmodul.eux.SedController
 import no.nav.eessi.eessifagmodul.models.InstitusjonItem
 import no.nav.eessi.eessifagmodul.models.Nav
 import no.nav.eessi.eessifagmodul.models.SED

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/prefill/krav/PrefillP2000APUtlandInnvTest.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/prefill/krav/PrefillP2000APUtlandInnvTest.kt
@@ -1,6 +1,6 @@
 package no.nav.eessi.eessifagmodul.prefill.krav
 
-import no.nav.eessi.eessifagmodul.controllers.SedController
+import no.nav.eessi.eessifagmodul.eux.SedController
 import no.nav.eessi.eessifagmodul.models.InstitusjonItem
 import no.nav.eessi.eessifagmodul.models.Nav
 import no.nav.eessi.eessifagmodul.models.SED

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/prefill/krav/PrefillP2000MedIngendata.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/prefill/krav/PrefillP2000MedIngendata.kt
@@ -1,6 +1,6 @@
 package no.nav.eessi.eessifagmodul.prefill.krav
 
-import no.nav.eessi.eessifagmodul.controllers.SedController
+import no.nav.eessi.eessifagmodul.eux.SedController
 import no.nav.eessi.eessifagmodul.models.InstitusjonItem
 import no.nav.eessi.eessifagmodul.models.Nav
 import no.nav.eessi.eessifagmodul.models.PensjoninformasjonException

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/prefill/krav/PrefillP2200-AP-21975717Test.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/prefill/krav/PrefillP2200-AP-21975717Test.kt
@@ -1,6 +1,6 @@
 package no.nav.eessi.eessifagmodul.prefill.krav
 
-import no.nav.eessi.eessifagmodul.controllers.SedController
+import no.nav.eessi.eessifagmodul.eux.SedController
 import no.nav.eessi.eessifagmodul.models.InstitusjonItem
 import no.nav.eessi.eessifagmodul.models.SED
 import no.nav.eessi.eessifagmodul.prefill.AbstractPrefillIntegrationTestHelper

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/services/PrefillServiceTest.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/services/PrefillServiceTest.kt
@@ -9,7 +9,6 @@ import no.nav.eessi.eessifagmodul.services.eux.BucSedResponse
 import no.nav.eessi.eessifagmodul.services.eux.BucUtils
 import no.nav.eessi.eessifagmodul.services.eux.EuxService
 import no.nav.eessi.eessifagmodul.services.eux.bucmodel.Buc
-import no.nav.eessi.eessifagmodul.services.eux.bucmodel.ParticipantsItem
 import no.nav.eessi.eessifagmodul.services.eux.bucmodel.ShortDocumentItem
 import no.nav.eessi.eessifagmodul.utils.mapJsonToAny
 import no.nav.eessi.eessifagmodul.utils.typeRefs


### PR DESCRIPTION
A part of restructuring from Package by Layer to Package by Feature.

arkiv:
- SafController

eux:
- BucController
- SedController

geo:
- LandkodeController
- PostkodeController

pensjon:
- PensjonController

person:
- PersonController
- NavRegistreOppslagController
- AktoerIdHelper