### PR TITLE
Henter opprettet dato fra datoOpprettet istedet for relevanteDatoer

### DIFF
--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/services/saf/SafGraphQLModel.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/services/saf/SafGraphQLModel.kt
@@ -15,6 +15,7 @@ data class SafRequest(
                         "verdi " +
                     "}" +
                     "journalpostId " +
+                    "datoOpprettet " +
                     "tittel " +
                     "tema " +
                     "dokumenter {" +
@@ -24,10 +25,6 @@ data class SafRequest(
                             "variantformat" +
                         "} " +
                     "} " +
-                    "relevanteDatoer {" +
-                        "dato " +
-                        "datotype " +
-                    "}" +
                 "}}}",
         val variables: Variables
 ) {
@@ -77,10 +74,10 @@ data class DokumentoversiktBruker(val journalposter: List<Journalpost>)
 data class Journalpost(
         val tilleggsopplysninger: List<Map<String, String>>,
         val journalpostId: String,
+        val datoOpprettet: String,
         val tittel: String,
         val tema: String,
-        val dokumenter: List<Dokument>,
-        val relevanteDatoer: List<DatoHolder>
+        val dokumenter: List<Dokument>
 )
 
 data class Dokument(
@@ -91,11 +88,6 @@ data class Dokument(
 
 data class Dokumentvarianter(
         val variantformat: VariantFormat
-)
-
-data class DatoHolder(
-        val dato: String,
-        val datotype: String
 )
 
 data class HentdokumentInnholdResponse (

--- a/src/test/resources/json/saf/hentMetadataResponse.json
+++ b/src/test/resources/json/saf/hentMetadataResponse.json
@@ -5,6 +5,7 @@
         {
           "tilleggsopplysninger": [],
           "journalpostId": "439560100",
+          "datoOpprettet": "2018-06-08T17:06:58",
           "tittel": "MASKERT_FELT",
           "tema": "SYK",
           "dokumenter": [
@@ -17,25 +18,12 @@
                 }
               ]
             }
-          ],
-          "relevanteDatoer": [
-            {
-              "dato": "2018-12-27T14:42:24",
-              "datotype": "DATO_DOKUMENT"
-            },
-            {
-              "dato": "2018-12-27T14:42:27",
-              "datotype": "DATO_JOURNALFOERT"
-            },
-            {
-              "dato": "2018-12-27T14:42:24",
-              "datotype": "DATO_REGISTRERT"
-            }
           ]
         },
         {
           "tilleggsopplysninger": [],
           "journalpostId": "439532144",
+          "datoOpprettet": "2018-06-08T17:06:58",
           "tittel": "MASKERT_FELT",
           "tema": "SYK",
           "dokumenter": [
@@ -50,20 +38,6 @@
                   "variantformat": "PRODUKSJON"
                 }
               ]
-            }
-          ],
-          "relevanteDatoer": [
-            {
-              "dato": "2018-12-26T00:00",
-              "datotype": "DATO_DOKUMENT"
-            },
-            {
-              "dato": "2018-12-26T18:30:50",
-              "datotype": "DATO_JOURNALFOERT"
-            },
-            {
-              "dato": "2018-12-26T00:00",
-              "datotype": "DATO_REGISTRERT"
             }
           ]
         }


### PR DESCRIPTION
DATO_DOKUMENT som representerer opprettelse dato for dokumentet er ikke alltid tilstede i relevanteDatoer , det hentes derfor fra datoOpprettet istedet