### PR TITLE
Flyttet /ytelseKravtype/{rinanr}/{documentid} fra Buc til SedController

### DIFF
--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/controllers/BucController.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/controllers/BucController.kt
@@ -111,17 +111,6 @@ class BucController(private val euxService: EuxService,
 
     }
 
-    //ny knall for journalforing app henter ytelsetype ut ifra P15000
-    @ApiOperation("Henter ytelsetype fra P15000 på valgt Buc og Documentid")
-    @GetMapping("/ytelseKravtype/{rinanr}/{documentid}")
-    fun getYtelseKravtype(@PathVariable("rinanr", required = true) rinanr: String,
-                          @PathVariable("documentid", required = false) documentid: String): Krav {
-
-        logger.debug("Henter opp ytelseKravType fra P15000, feiler hvis ikke P15000")
-        return euxService.hentYtelseKravtype(rinanr, documentid)
-
-    }
-
     //flyttes to BucController
     @ApiOperation("Oppretter ny tom BUC i RINA via eux-api. ny api kall til eux")
     @PostMapping("/{buctype}")

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/controllers/SedController.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/controllers/SedController.kt
@@ -2,10 +2,7 @@ package no.nav.eessi.eessifagmodul.controllers
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.annotations.ApiOperation
-import no.nav.eessi.eessifagmodul.models.IkkeGyldigKallException
-import no.nav.eessi.eessifagmodul.models.InstitusjonItem
-import no.nav.eessi.eessifagmodul.models.SED
-import no.nav.eessi.eessifagmodul.models.SEDType
+import no.nav.eessi.eessifagmodul.models.*
 import no.nav.eessi.eessifagmodul.person.AktoerIdHelper
 import no.nav.eessi.eessifagmodul.prefill.PrefillDataModel
 import no.nav.eessi.eessifagmodul.services.PrefillService
@@ -141,6 +138,18 @@ class SedController(private val euxService: EuxService,
 
         return ResponseEntity.ok().body(mapAnyToJson(resultListe.filterPensionSedAndSort()))
     }
+
+    //ny knall for journalforing app henter ytelsetype ut ifra P15000
+    @ApiOperation("Henter ytelsetype fra P15000 på valgt Buc og Documentid")
+    @GetMapping("/ytelseKravtype/{rinanr}/sedid/{documentid}")
+    fun getPinOgYtelseKravtype(@PathVariable("rinanr", required = true) rinanr: String,
+                               @PathVariable("documentid", required = false) documentid: String): PinOgKrav {
+
+        logger.debug("Henter opp ytelseKravType fra P2100 eller P15000, feiler hvis ikke rett SED")
+        return euxService.hentFnrOgYtelseKravtype(rinanr, documentid)
+
+    }
+
 
     //validatate request and convert to PrefillDataModel
     fun buildPrefillDataModelOnExisting(request: ApiRequest): PrefillDataModel {

--- a/src/main/kotlin/no/nav/eessi/eessifagmodul/models/NavModel.kt
+++ b/src/main/kotlin/no/nav/eessi/eessifagmodul/models/NavModel.kt
@@ -116,6 +116,12 @@ data class PersonpinEndringer(
         val nytt: String? = null
 )
 
+//P15000-P2100 levende PinID og Krav
+data class PinOgKrav(
+        val fnr: String? = null,
+        val krav: Krav? = null
+)
+
 
 //H070
 data class Doedsfall(

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/controllers/BucControllerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/controllers/BucControllerTest.kt
@@ -1,43 +1,25 @@
 package no.nav.eessi.eessifagmodul.controllers
 
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.whenever
-import no.nav.eessi.eessifagmodul.models.*
-import no.nav.eessi.eessifagmodul.person.aktoerregister.AktoerregisterService
-import no.nav.eessi.eessifagmodul.services.eux.BucUtils
-import no.nav.eessi.eessifagmodul.services.eux.EuxService
-import no.nav.eessi.eessifagmodul.services.eux.RinaAksjon
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
-import java.nio.file.Files
-import java.nio.file.Paths
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
-
-@RunWith(MockitoJUnitRunner.Silent::class)
+//@RunWith(MockitoJUnitRunner.Silent::class)
 class BucControllerTest {
-
-    @Mock
-    lateinit var mockEuxService: EuxService
-
-    @Mock
-    lateinit var mockBucUtils: BucUtils
-
-    @Mock
-    lateinit var mockAktoerregisterService: AktoerregisterService
-
-    private lateinit var bucController: BucController
-
-    @Before
-    fun GetItOn() {
-        this.bucController = BucController(mockEuxService, mockAktoerregisterService)
-        doReturn("12105033302").whenever(mockAktoerregisterService).hentGjeldendeNorskIdentForAktorId(ArgumentMatchers.anyString())
-    }
-
+//
+//    @Mock
+//    lateinit var mockEuxService: EuxService
+//
+//    @Mock
+//    lateinit var mockBucUtils: BucUtils
+//
+//    @Mock
+//    lateinit var mockAktoerregisterService: AktoerregisterService
+//
+//    private lateinit var bucController: BucController
+//
+//    @Before
+//    fun GetItOn() {
+//        this.bucController = BucController(mockEuxService, mockAktoerregisterService)
+//        doReturn("12105033302").whenever(mockAktoerregisterService).hentGjeldendeNorskIdentForAktorId(ArgumentMatchers.anyString())
+//    }
+//
 //    @Test
 //    fun getMuligeAksjonerUtenFilter() {
 //        val filepath = "src/test/resources/json/aksjoner/noen_aksjoner.json"
@@ -71,23 +53,6 @@ class BucControllerTest {
 //        assertEquals(3, result.size)
 //    }
 
-
-    @Test
-    fun getYtelseKravtypeOk() {
-        //val mockSedKrav = SED(sed = "P15000", sedGVer = "4", sedVer = "1", nav = Nav(krav = Krav(dato = "2019-02-01", type = "01")))
-        val mockKrav = Krav(dato = "2019-02-01", type = "01")
-
-        doReturn(mockKrav).whenever(mockEuxService).
-                hentYtelseKravtype(
-                        ArgumentMatchers.anyString(),
-                        ArgumentMatchers.anyString()
-                )
-
-        val mockResult = bucController.getYtelseKravtype("12123", "3123123")
-
-        assertEquals("01", mockResult.type)
-        assertEquals("2019-02-01", mockResult.dato)
-    }
 
 
 }

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/controllers/SedControllerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/controllers/SedControllerTest.kt
@@ -372,4 +372,22 @@ class SedControllerTest {
         val validSedListforBuc = mapJsonToAny(json, typeRefs<List<String>>())
         assertEquals(2, validSedListforBuc.size)
     }
+
+    @Test
+    fun getYtelseKravtypeOk() {
+        val mockKrav = PinOgKrav(fnr = "13212312", krav =  Krav(dato = "2019-02-01", type = "01"))
+
+        doReturn(mockKrav).whenever(mockEuxService).
+                hentFnrOgYtelseKravtype(
+                        ArgumentMatchers.anyString(),
+                        ArgumentMatchers.anyString()
+                )
+
+        val mockResult =  sedController.getPinOgYtelseKravtype("12123", "3123123")
+
+        assertEquals("13212312", mockResult.fnr)
+        assertEquals("01", mockResult.krav?.type)
+        assertEquals("2019-02-01", mockResult.krav?.dato)
+    }
+
 }

--- a/src/test/kotlin/no/nav/eessi/eessifagmodul/services/eux/EuxServiceTest.kt
+++ b/src/test/kotlin/no/nav/eessi/eessifagmodul/services/eux/EuxServiceTest.kt
@@ -498,7 +498,37 @@ class EuxServiceTest {
     }
 
     @Test
-    fun hentYtelseKravtypeTesterPaaP15000ok() {
+    fun hentNorskFnrPaalisteavPin() {
+        val list = listOf(
+                PinItem(sektor = "03", land = "SE", identifikator = "00987654321", institusjonsnavn = "SE"),
+                PinItem(sektor = "02", land = "NO", identifikator = "12345678900", institusjonsnavn = "NAV"),
+                PinItem(sektor = "02", land = "DK", identifikator = "05467898321", institusjonsnavn = "DK")
+            )
+
+        val result = service.getFnrMedLandkodeNO(list)
+        assertEquals("12345678900", result)
+    }
+
+    @Test
+    fun hentNorskFnrPaalisteavPinListeTom() {
+        val result = service.getFnrMedLandkodeNO(listOf())
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun hentNorskFnrPaalisteavPinListeIngenNorske() {
+        val list = listOf(
+                PinItem(sektor = "03", land = "SE", identifikator = "00987654321", institusjonsnavn = "SE"),
+                PinItem(sektor = "02", land = "DK", identifikator = "05467898321", institusjonsnavn = "DK")
+        )
+        val result = service.getFnrMedLandkodeNO(list)
+        assertEquals(null, result)
+
+    }
+
+
+    @Test
+    fun hentYtelseKravtypeTesterPaaP15000Alderpensjon() {
         val filepath = "src/test/resources/json/nav/P15000-NAV.json"
         val json = String(Files.readAllBytes(Paths.get(filepath)))
         assertTrue(validateJson(json))
@@ -514,12 +544,56 @@ class EuxServiceTest {
                 eq(String::class.java))
         ).thenReturn(response)
 
-        //val sed = getSedOnBucByDocumentId(euxCaseId, documentId)
+        val result = service.hentFnrOgYtelseKravtype("1234567890","100001000010000")
+        assertEquals("21712", result.fnr)
+        assertEquals("01", result.krav?.type)
+        assertEquals("2019-02-01", result.krav?.dato)
+    }
 
-        val kravytelse = service.hentYtelseKravtype("1234567890","100001000010000")
+    @Test
+    fun hentYtelseKravtypeTesterPaaP15000Gjennlevende() {
+        val filepath = "src/test/resources/json/nav/P15000Gjennlevende-NAV.json"
+        val json = String(Files.readAllBytes(Paths.get(filepath)))
+        assertTrue(validateJson(json))
 
-        assertEquals("01", kravytelse.type)
-        assertEquals("2019-02-01", kravytelse.dato)
+        val orgsed = mapJsonToAny(json, typeRefs<SED>())
+
+        val response: ResponseEntity<String> = ResponseEntity(json, HttpStatus.OK)
+
+        whenever(mockEuxrestTemplate.exchange(
+                anyString(),
+                eq(HttpMethod.GET),
+                eq(null),
+                eq(String::class.java))
+        ).thenReturn(response)
+
+        val result = service.hentFnrOgYtelseKravtype("1234567890","100001000010000")
+        assertEquals("32712", result.fnr)
+        assertEquals("02", result.krav?.type)
+        assertEquals("2019-02-01", result.krav?.dato)
+    }
+
+    @Test
+    fun hentYtelseKravtypeTesterPaaP2100OK() {
+        val filepath = "src/test/resources/json/nav/P2100-NAV-unfin.json"
+        val json = String(Files.readAllBytes(Paths.get(filepath)))
+        assertTrue(validateJson(json))
+
+        val orgsed = mapJsonToAny(json, typeRefs<SED>())
+        val response: ResponseEntity<String> = ResponseEntity(json, HttpStatus.OK)
+
+        whenever(mockEuxrestTemplate.exchange(
+                anyString(),
+                eq(HttpMethod.GET),
+                eq(null),
+                eq(String::class.java))
+        ).thenReturn(response)
+
+        val result = service.hentFnrOgYtelseKravtype("1234567890","100001000010000")
+
+        assertEquals("123456789012", result.fnr)
+        assertEquals(null, result.krav?.type)
+        assertEquals("2015-12-17", result.krav?.dato)
     }
 
     @Test(expected = SedDokumentIkkeGyldigException::class)
@@ -539,7 +613,7 @@ class EuxServiceTest {
                 eq(String::class.java))
         ).thenReturn(response)
 
-        service.hentYtelseKravtype("1234567890","100001000010000")
+        service.hentFnrOgYtelseKravtype("1234567890","100001000010000")
     }
 
     @Test

--- a/src/test/resources/json/nav/P15000Gjennlevende-NAV.json
+++ b/src/test/resources/json/nav/P15000Gjennlevende-NAV.json
@@ -1,0 +1,134 @@
+{
+  "nav" : {
+    "bruker" : {
+      "mor" : {
+        "person" : {
+          "etternavnvedfoedsel" : "2184",
+          "fornavn" : "2185"
+        }
+      },
+      "person" : {
+        "fornavn" : "Mandag",
+        "kjoenn" : "M",
+        "etternavn" : "Dag",
+        "kontakt" : {
+          "email" : [ {
+            "adresse" : "ingenerhjemme@online.no"
+          } ],
+          "telefon" : [ {
+            "nummer" : "456789321",
+            "type" : "mobil"
+          } ]
+        },
+        "etternavnvedfoedsel" : "215",
+        "foedselsdato" : "1957-05-27",
+        "tidligereetternavn" : "2212",
+        "statsborgerskap" : [ {
+          "land" : "NO"
+        } ],
+        "pin" : [ {
+          "institusjonsnavn" : "12347, NAVT002, NO",
+          "identifikator" : "21712",
+          "sektor" : "pensjoner",
+          "land" : "NO",
+          "institusjonsid" : "NO:NAVT002"
+        } ],
+        "foedested" : {
+          "region" : "21812",
+          "by" : "21811",
+          "land" : "NO"
+        },
+        "fornavnvedfoedsel" : "216",
+        "tidligerefornavn" : "2213"
+      },
+      "adresse" : {
+        "bygning" : "2222",
+        "region" : "2225",
+        "postnummer" : "2224",
+        "by" : "2223",
+        "land" : "NO",
+        "gate" : "2221"
+      },
+      "far" : {
+        "person" : {
+          "fornavn" : "2183",
+          "etternavnvedfoedsel" : "2182"
+        }
+      }
+    },
+    "eessisak" : [ {
+      "institusjonsnavn" : "12347, NAVT002, NO",
+      "saksnummer" : "112",
+      "land" : "NO",
+      "institusjonsid" : "NO:NAVT002"
+    } ],
+    "krav" : {
+      "dato" : "2019-02-01",
+      "type" : "02"
+    }
+  },
+  "pensjon" : {
+    "gjenlevende" : {
+      "person" : {
+        "kontakt" : {
+          "telefon" : [ {
+            "type" : "arbeid",
+            "nummer" : "1234567890"
+          } ],
+          "email" : [ {
+            "adresse" : "knockingonheavens@heaven.com"
+          } ]
+        },
+        "etternavnvedfoedsel" : "325",
+        "foedested" : {
+          "region" : "32812",
+          "by" : "32811",
+          "land" : "NO"
+        },
+        "pin" : [ {
+          "sektor" : "pensjoner",
+          "land" : "NO",
+          "institusjonsid" : "NO:NAVT002",
+          "identifikator" : "32712",
+          "institusjonsnavn" : "12347, NAVT002, NO"
+        } ],
+        "fornavn" : "322",
+        "kjoenn" : "K",
+        "relasjontilavdod" : {
+          "relasjon" : "01"
+        },
+        "tidligereetternavn" : "3312",
+        "fornavnvedfoedsel" : "326",
+        "foedselsdato" : "1962-04-25",
+        "tidligerefornavn" : "3313",
+        "etternavn" : "321",
+        "statsborgerskap" : [ {
+          "land" : "NO"
+        } ]
+      },
+      "adresse" : {
+        "postnummer" : "3324",
+        "by" : "3323",
+        "land" : "NO",
+        "gate" : "3321",
+        "bygning" : "3322",
+        "region" : "3325"
+      },
+      "mor" : {
+        "person" : {
+          "etternavnvedfoedsel" : "3284",
+          "fornavn" : "3285"
+        }
+      },
+      "far" : {
+        "person" : {
+          "fornavn" : "3283",
+          "etternavnvedfoedsel" : "3282"
+        }
+      }
+    }
+  },
+  "sedVer" : "1",
+  "sedGVer" : "4",
+  "sed" : "P15000"
+}


### PR DESCRIPTION
Endrer på getYtelseKravtype getPinOgYtelseKravtype og returnerer PinOgKrav
fnr på levende ved P2100 og P15000 (uansett kravtype)
kravtype og dato