### PR TITLE
Øke timeout mellom fagmodul og Eux-Rina da bucSedView er svært tung

### DIFF
--- a/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/eux/EuxRestTemplate.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/eux/EuxRestTemplate.kt
@@ -15,6 +15,7 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.client.DefaultResponseErrorHandler
 import org.springframework.web.client.RestTemplate
+import java.time.Duration
 
 @Component
 class EuxRestTemplate(private val oidcRequestContextHolder: OIDCRequestContextHolder, private val registry: MeterRegistry) {
@@ -27,6 +28,8 @@ class EuxRestTemplate(private val oidcRequestContextHolder: OIDCRequestContextHo
         return templateBuilder
                 .rootUri(url)
                 .errorHandler(DefaultResponseErrorHandler())
+                .setReadTimeout(Duration.ofSeconds(120))
+                .setConnectTimeout(Duration.ofSeconds(120))
                 .additionalInterceptors(
                         RequestIdHeaderInterceptor(),
                         RequestResponseLoggerInterceptor(),

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration debug="true">
 
-    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %d{dd-MM-yyyy HH:mm:ss.SSS} %magenta([%thread]) %highlight(%-5level) %logger{20} - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
 
-    <logger name="no.nav" level="DEBUG"/>
-    <!--<logger name="no.nav.eessi.pensjon.logging.RequestResponseLoggerInterceptor" level="DEBUG"/>-->
+    <root level="DEBUG">
+        <appender-ref ref="stdout" />
+    </root>
+
 
 </configuration>


### PR DESCRIPTION
Prøver å legge til connection og readtimeout mellom fagmodul og eux-rina-api. Spesielt knyttet til UI tjenesten getBucogSedView /buc/detaljer/{aktoerid} da denne er svært tung prossess og blir bare tyngre jo flere BUCs det finnes på en person.