### PR TITLE
oppdatert generering av BucSedAndView

### DIFF
--- a/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/api/BucController.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/api/BucController.kt
@@ -113,19 +113,19 @@ class BucController(private val euxService: EuxService,
                         @PathVariable("sakid", required = false) sakid: String? = "",
                         @PathVariable("euxcaseid", required = false) euxcaseid: String? = ""): List<BucAndSedView> {
         auditlogger.log("getBucogSedView", aktoerid)
-        logger.debug("1 prøver å dekode til fnr fra aktoerid: $aktoerid")
+        logger.debug(" prøver å dekode til fnr fra aktoerid: $aktoerid")
 
         val fnr = aktoerIdHelper.hentPinForAktoer(aktoerid)
         val rinaSakIderFraDokumentMetadata = safService.hentRinaSakIderFraDokumentMetadata(aktoerid)
         val rinasakIdList = euxService.getFilteredArchivedaRinasaker(euxService.getRinasaker(fnr, rinaSakIderFraDokumentMetadata))
-        return euxService.getBucAndSedView( rinasakIdList, aktoerid)
+        return euxService.getBucAndSedView( rinasakIdList )
     }
 
     @ApiOperation("Henter ut en json struktur for type og sed menyliste for ui. ny api kall til eux")
     @GetMapping("/enkeldetalj/{euxcaseid}")
     fun getSingleBucogSedView(@PathVariable("euxcaseid", required = true) euxcaseid: String): BucAndSedView {
         auditlogger.log("getSingleBucogSedView")
-        logger.debug("1 prøver å hente en enkel buc på : $euxcaseid")
+        logger.debug(" prøver å hente en enkel buc på : $euxcaseid")
 
         return euxService.getSingleBucAndSedView(euxcaseid)
     }
@@ -142,7 +142,7 @@ class BucController(private val euxService: EuxService,
 
         //create bucDetail back from newly created buc call eux-rina-api to get data.
         val buc = euxService.getBuc(euxCaseId)
-        return BucAndSedView.from(buc, "")
+        return BucAndSedView.from(buc)
     }
 
     @ApiOperation("Legger til et vedlegg for det gitte dokumentet")

--- a/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/eux/BucAndSedView.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/eux/BucAndSedView.kt
@@ -4,42 +4,40 @@ import no.nav.eessi.pensjon.fagmodul.eux.bucmodel.Buc
 import no.nav.eessi.pensjon.fagmodul.eux.bucmodel.ShortDocumentItem
 import no.nav.eessi.pensjon.fagmodul.models.InstitusjonItem
 import no.nav.eessi.pensjon.utils.mapAnyToJson
+import no.nav.eessi.pensjon.utils.toJson
 
 data class BucAndSedView(
         val type: String,
         val caseId: String,
         val creator: InstitusjonItem? = null,
         val sakType: String? = null,
-        val aktoerId: String,
         val status: String? = null,
         val startDate: Long? = null,
         val lastUpdate: Long? = null,
-        val institusjon: List<InstitusjonItem>,
-        val seds: List<ShortDocumentItem>
+        val institusjon: List<InstitusjonItem>? = null,
+        val seds: List<ShortDocumentItem>? = null,
+        val error: String? = null
 ) {
-    fun toJson(): String {
-        return mapAnyToJson(this, false)
-    }
-
-    fun toJsonSkipEmpty(): String {
-        return mapAnyToJson(this, true)
-    }
-
     override fun toString(): String {
         return toJson()
     }
 
     companion object {
-        fun from(buc: Buc, aktoerid: String): BucAndSedView {
+        fun fromErr(error: String?): BucAndSedView {
+            return BucAndSedView(
+                    type = "",
+                    caseId = "",
+                    error = error
+            )
+        }
+        fun from(buc: Buc): BucAndSedView {
             val bucUtil = BucUtils(buc)
             return BucAndSedView(
                     type = bucUtil.getProcessDefinitionName()!!,
                     creator = bucUtil.getCaseOwnerOrCreator(),
                     caseId = buc.id?: "n/a",
-                    sakType = "",
                     startDate = bucUtil.getStartDateLong(),
                     lastUpdate = bucUtil.getLastDateLong(),
-                    aktoerId = aktoerid,
                     status = bucUtil.getStatus(),
                     institusjon = bucUtil.getParticipants().map {
                         InstitusjonItem(

--- a/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/metrics/Metrics.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/metrics/Metrics.kt
@@ -4,7 +4,8 @@ import io.micrometer.core.instrument.Counter
 import no.nav.eessi.pensjon.metrics.counter
 
 fun getCounter(key: String): Counter {
-    val countermap = mapOf("AKSJONOK" to counter("eessipensjon_fagmodul.euxmuligeaksjoner", "vellykkede"),
+    val countermap = mapOf(
+            "AKSJONOK" to counter("eessipensjon_fagmodul.euxmuligeaksjoner", "vellykkede"),
             "SENDSEDOK" to counter("eessipensjon_fagmodul.sendsed", "vellykkede"),
             "SENDSEDFEIL" to counter("eessipensjon_fagmodul.sendsed", "feilede"),
             "HENTSEDOK" to counter("eessipensjon_fagmodul.hentsed", "vellykkede"),

--- a/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/eux/BucUtilsTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/eux/BucUtilsTest.kt
@@ -422,7 +422,7 @@ class BucUtilsTest {
         val bucjson = getTestJsonFile("buc-280670.json")
         val buc = mapJsonToAny(bucjson, typeRefs<Buc>())
 
-        val bucview =  BucAndSedView.from(buc, "")
+        val bucview =  BucAndSedView.from(buc)
 
         assertEquals(1567155195638, bucview.startDate)
         assertEquals(1567155212000, bucview.lastUpdate)
@@ -433,10 +433,18 @@ class BucUtilsTest {
         val bucjson = getTestJsonFile("buc-279020big.json")
         val buc = mapJsonToAny(bucjson, typeRefs<Buc>())
 
-        val bucview =  BucAndSedView.from(buc, "")
+        val bucview =  BucAndSedView.from(buc)
         assertEquals(1567088832589, bucview.startDate)
         assertEquals(1567178490000, bucview.lastUpdate)
     }
+
+    @Test
+    fun parseAndTestBucMockError() {
+        val error = "Error; no access"
+        val bucview =  BucAndSedView.fromErr(error)
+        assertEquals(error, bucview.error)
+    }
+
 
     @Test
     fun bucsedandviewDisplaySedsWithParentIdToReply() {
@@ -457,11 +465,11 @@ class BucUtilsTest {
         val bucjson = getTestJsonFile("buc-285268-answerid.json")
         val buc = mapJsonToAny(bucjson, typeRefs<Buc>())
 
-        val bucAndSedView = BucAndSedView.from(buc, "amatør")
+        val bucAndSedView = BucAndSedView.from(buc)
 
         val seds = bucAndSedView.seds
-        val filterParentId = seds.stream().filter { it.parentDocumentId != null }.toList()
-        assertEquals(3, filterParentId.size)
+        val filterParentId = seds?.filter { it.parentDocumentId != null }?.toList()
+        assertEquals(3, filterParentId?.size)
 
         assertEquals("NO", bucAndSedView.creator?.country)
         assertEquals("NO:NAVT003", bucAndSedView.creator?.institution)
@@ -475,10 +483,10 @@ class BucUtilsTest {
         val bucjson = getTestJsonFile("buc-287679short.json")
         val buc = mapJsonToAny(bucjson, typeRefs<Buc>())
 
-        val bucAndSedView = BucAndSedView.from(buc, "amatør")
+        val bucAndSedView = BucAndSedView.from(buc)
 
         val seds = bucAndSedView.seds
-        assertEquals(1, seds.size)
+        assertEquals(1, seds?.size)
 
         assertEquals("NO", bucAndSedView.creator?.country)
         assertEquals("NO:NAVT002", bucAndSedView.creator?.institution)
@@ -488,10 +496,10 @@ class BucUtilsTest {
 
     @Test
     fun bucsedandviewCheckforCaseOwner() {
-        val bucAndSedView = BucAndSedView.from(buc, "amatør")
+        val bucAndSedView = BucAndSedView.from(buc)
 
         val seds = bucAndSedView.seds
-        assertEquals(15, seds.size)
+        assertEquals(15, seds?.size)
 
         assertEquals("NO", bucAndSedView.creator?.country)
         assertEquals("NO:NAVT003", bucAndSedView.creator?.institution)
@@ -503,14 +511,17 @@ class BucUtilsTest {
     fun hentutBucsedviewmedDato() {
         val bucjson = getTestJsonFile("buc-279020big.json")
         val buc = mapJsonToAny(bucjson, typeRefs<Buc>())
-        val bucAndSedView = BucAndSedView.from(buc, "Dummy aktoerid")
-        val seds = bucAndSedView.seds
+        val bucAndSedView = BucAndSedView.from(buc)
+
+        val seds = bucAndSedView.seds.orEmpty()
+
         assertEquals(25, seds.size)
         assertEquals("NO", bucAndSedView.creator?.country)
         assertEquals("NO:NAVT002", bucAndSedView.creator?.institution)
         assertEquals("NAVT002", bucAndSedView.creator?.name)
         assertEquals(1567088832589, bucAndSedView.startDate)
         assertEquals(1567178490000, bucAndSedView.lastUpdate)
+
         val startDate = DateTimeFormatter.ISO_INSTANT.format(java.time.Instant.ofEpochMilli (1567088832589))
         val startDlen = startDate.length -5
         assertEquals(startDate.substring(0, startDlen), buc.startDate.toString().substring(0,19))

--- a/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/eux/EuxServiceTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/eux/EuxServiceTest.kt
@@ -458,7 +458,8 @@ class EuxServiceTest {
                 .exchange( ArgumentMatchers.contains("buc/") ,
                 eq(HttpMethod.GET), eq(null), eq(String::class.java))
 
-        val result = service.getBucAndSedView(rinasakresult, "001122334455")
+        //"001122334455"
+        val result = service.getBucAndSedView(rinasakresult)
 
         assertNotNull(result)
         assertEquals(6, orgRinasaker.size)
@@ -470,9 +471,10 @@ class EuxServiceTest {
         var lastUpdate: Long = 0
         firstJson.lastUpdate?.let { lastUpdate = it }
         assertEquals("2019-05-20T16:35:34",  Instant.ofEpochMilli(lastUpdate).atZone(ZoneId.systemDefault()).toLocalDateTime().toString())
-        assertEquals(18, firstJson.seds.size)
+        assertEquals(18, firstJson.seds?.size)
 
         val json = firstJson.toJson()
+        println(json)
 
         val bucdetaljerpath = "src/test/resources/json/buc/bucdetaljer-158123.json"
         val bucdetaljer = String(Files.readAllBytes(Paths.get(bucdetaljerpath)))
@@ -486,10 +488,14 @@ class EuxServiceTest {
         val bucStr = String(Files.readAllBytes(Paths.get(bucjson)))
         assertTrue(validateJson(bucStr))
 
-        whenever(mockEuxrestTemplate.exchange(
-                not(eq("/rinasaker?Fødselsnummer=12345678900&RINASaksnummer=&BuCType=&Status=")),
-                eq(HttpMethod.GET), eq(null), eq(String::class.java)))
-                .thenReturn(ResponseEntity.ok(bucStr))
+        doReturn(ResponseEntity.ok(bucStr))
+                .whenever(mockEuxrestTemplate)
+                .exchange(
+                        ArgumentMatchers.contains("/buc/158123") ,
+                        eq(HttpMethod.GET),
+                        eq(null),
+                        eq(String::class.java)
+                )
 
         val firstJson = service.getSingleBucAndSedView("158123")
 
@@ -497,7 +503,7 @@ class EuxServiceTest {
         var lastUpdate: Long = 0
         firstJson.lastUpdate?.let { lastUpdate = it }
         assertEquals("2019-05-20T16:35:34",  Instant.ofEpochMilli(lastUpdate).atZone(ZoneId.systemDefault()).toLocalDateTime().toString())
-        assertEquals(18, firstJson.seds.size)
+        assertEquals(18, firstJson.seds?.size)
     }
 
     @Test

--- a/src/test/resources/json/buc/bucdetaljer-158123.json
+++ b/src/test/resources/json/buc/bucdetaljer-158123.json
@@ -6,8 +6,7 @@
     "institution" : "NO:NAVT003",
     "name" : "NAVT003"
   },
-  "sakType" : "",
-  "aktoerId" : "001122334455",
+  "sakType" : null,
   "status" : "open",
   "startDate" : 1557392989122,
   "lastUpdate" : 1558362934000,
@@ -1026,5 +1025,6 @@
     } ],
     "attachments" : [ ],
     "version" : "1"
-  } ]
+  } ],
+  "error" : null
 }


### PR DESCRIPTION
Støtter tom objekt BucSedAndView dersom feil/error oppstår ved henting av buc fra rina-eux-api. 