### PR TITLE
stoppe preutfylling av adresse ved diskresjonkode på person

### DIFF
--- a/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/prefill/tps/PrefillAdresseTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/prefill/tps/PrefillAdresseTest.kt
@@ -2,20 +2,24 @@ package no.nav.eessi.pensjon.fagmodul.prefill.tps
 
 import no.nav.eessi.pensjon.services.geo.LandkodeService
 import no.nav.eessi.pensjon.services.geo.PostnummerService
-import no.nav.tjeneste.virksomhet.person.v3.informasjon.Bostedsadresse
-import no.nav.tjeneste.virksomhet.person.v3.informasjon.Gateadresse
-import no.nav.tjeneste.virksomhet.person.v3.informasjon.Landkoder
-import no.nav.tjeneste.virksomhet.person.v3.informasjon.Person
-import no.nav.tjeneste.virksomhet.person.v3.informasjon.Postnummer
+import no.nav.eessi.pensjon.services.personv3.BrukerMock
+import no.nav.tjeneste.virksomhet.person.v3.informasjon.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class PrefillAdresseTest{
 
+    lateinit var prefillAdresse: PrefillAdresse
+
+    @BeforeEach
+    fun beforeStart() {
+        prefillAdresse = PrefillAdresse(PostnummerService(), LandkodeService())
+    }
+
     @Test
     fun `create personAdresse`() {
-        val prefillAdresse = PrefillAdresse(PostnummerService(), LandkodeService())
 
         val landkode = Landkoder()
         landkode.value = "NOR"
@@ -41,4 +45,29 @@ class PrefillAdresseTest{
         assertEquals("NO", result.land)
         assertEquals("Kirkeveien 12", result.gate)
         assertEquals("OSLO", result.by)
-    }}
+    }
+
+    @Test
+    fun adresseFeltDiskresjonFortroligPerson() {
+        val bruker = BrukerMock.createWith()
+        bruker?.diskresjonskode = Diskresjonskoder().withValue("SPFO")
+
+        val acual = prefillAdresse.createPersonAdresse(bruker ?: Bruker())
+
+        assertEquals(null, acual)
+
+    }
+
+    @Test
+    fun adresseFeltDiskresjonStrengtFortoligPerson() {
+        val bruker = BrukerMock.createWith()
+        bruker?.diskresjonskode = Diskresjonskoder().withValue("SPSF")
+
+        val acual = prefillAdresse.createPersonAdresse(bruker ?: Bruker())
+
+        assertEquals(null, acual)
+
+    }
+
+
+}

--- a/src/test/kotlin/no/nav/eessi/pensjon/services/personv3/PersonMock.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/services/personv3/PersonMock.kt
@@ -1,0 +1,47 @@
+package no.nav.eessi.pensjon.services.personv3
+
+import no.nav.tjeneste.virksomhet.person.v3.informasjon.*
+
+object PersonMock {
+    internal fun createWith(landkoder: Boolean = true, fornavn: String = "Test", etternavn: String = "Testesen"):
+            Person? = Person()
+                    .withPersonnavn(Personnavn()
+                            .withEtternavn(etternavn)
+                            .withFornavn(fornavn)
+                            .withSammensattNavn("$fornavn $etternavn"))
+                    .withKjoenn(Kjoenn().withKjoenn(Kjoennstyper().withValue("M")))
+                    .withStatsborgerskap(Statsborgerskap().withLand(Landkoder().withValue("NOR")))
+                    .withBostedsadresse(Bostedsadresse()
+                            .withStrukturertAdresse(Gateadresse()
+                                            .withGatenavn("Oppoverbakken")
+                                            .withHusnummer(66)
+                                            .withPoststed(Postnummer().withValue("1920"))
+                                            .withLandkode(when(landkoder){
+                                                        true -> Landkoder().withValue("NOR")
+                                                        else -> null
+                                            })))
+}
+
+object BrukerMock {
+    internal fun createWith(landkoder: Boolean = true, fornavn: String = "Test", etternavn: String = "Testesen"):
+            Bruker? = Bruker()
+            .withPersonnavn(Personnavn()
+                    .withEtternavn(etternavn)
+                    .withFornavn(fornavn)
+                    .withSammensattNavn("$fornavn $etternavn"))
+            .withKjoenn(Kjoenn().withKjoenn(Kjoennstyper().withValue("M")))
+            .withStatsborgerskap(Statsborgerskap().withLand(Landkoder().withValue("NOR")))
+            .withBostedsadresse(Bostedsadresse()
+                    .withStrukturertAdresse(Gateadresse()
+                            .withGatenavn("Oppoverbakken")
+                            .withHusnummer(66)
+                            .withPoststed(Postnummer().withValue("1920"))
+                            .withLandkode(when(landkoder){
+                                true -> Landkoder().withValue("NOR")
+                                else -> null
+                            })))
+            .withGeografiskTilknytning(when(landkoder) {
+                true -> Kommune().withGeografiskTilknytning("026123")
+                else -> null
+            })
+}


### PR DESCRIPTION
Det skal ikke preutfylles noe adressefelt for personer som mer merket med diskresjokode SPFO