### PR TITLE
test på en ugyldig P15000 skal blir avvist fra Fagmodul

### DIFF
--- a/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/eux/bucmodel/Buc.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/eux/bucmodel/Buc.kt
@@ -1,5 +1,8 @@
 package no.nav.eessi.pensjon.fagmodul.eux.bucmodel
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class Buc(
         var creator: Creator? = null,
         val attachments: List<Attachment>? = null,

--- a/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/sedmodel/SED.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/sedmodel/SED.kt
@@ -1,11 +1,13 @@
 package no.nav.eessi.pensjon.fagmodul.sedmodel
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import no.nav.eessi.pensjon.utils.mapJsonToAny
 import no.nav.eessi.pensjon.utils.toJson
 import no.nav.eessi.pensjon.utils.typeRefs
 
 // SED class main request class to basis
 // Strukturerte Elektroniske Dokumenter
+//@JsonIgnoreProperties(ignoreUnknown = true)
 data class SED(
         val sed: String? = null,
         val sedGVer: String? = "4",

--- a/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/sedmodel/SedP15000Test.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/sedmodel/SedP15000Test.kt
@@ -1,8 +1,11 @@
 package no.nav.eessi.pensjon.fagmodul.sedmodel
 
+import no.nav.eessi.pensjon.fagmodul.eux.IkkeFunnetException
+import no.nav.eessi.pensjon.utils.FagmodulJsonIllegalArgumentException
 import no.nav.eessi.pensjon.utils.toJson
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.skyscreamer.jsonassert.JSONAssert
 
 class SedP15000Test {
@@ -16,17 +19,22 @@ class SedP15000Test {
         val json = p15000sed.toJson()
         JSONAssert.assertEquals(p15000json, json, false)
 
-
         //hovedperson
         assertEquals("Mandag", p15000sed.nav?.bruker?.person?.fornavn)
         assertEquals(null, p15000sed.nav?.bruker?.bank?.konto?.sepa?.iban)
         assertEquals("21811", p15000sed.nav?.bruker?.person?.foedested?.by)
-
         assertEquals("ingenerhjemme@online.no", p15000sed.nav?.bruker?.person?.kontakt?.email?.first()?.adresse)
-
 
         //
         assertEquals("2019-02-01", p15000sed.nav?.krav?.dato)
         assertEquals("01", p15000sed.nav?.krav?.type)
+    }
+
+    @Test
+    fun `P15000 med element Sector feiler ved innlesing`() {
+        val p15000json = getTestJsonFile("P15000-SectorFeiler-NAV.json")
+        assertThrows<FagmodulJsonIllegalArgumentException> {
+            getSEDfromTestfile(p15000json)
+        }
     }
 }

--- a/src/test/resources/json/nav/P15000-SectorFeiler-NAV.json
+++ b/src/test/resources/json/nav/P15000-SectorFeiler-NAV.json
@@ -1,0 +1,20 @@
+{
+  "nav": {
+    "krav": {
+      "type": "01",
+      "dato": "2019-11-08"
+    },
+    "bruker": {
+      "person": {
+        "kjoenn": "M",
+        "etternavn": "SAKS",
+        "fornavn": "ARTIG",
+        "foedselsdato": "1980-02-01"
+      }
+    }
+  },
+  "sed": "P15000",
+  "Sector Components/Pensions/P15000": "Sector Components/Pensions/P15000",
+  "sedGVer": "4",
+  "sedVer": "1"
+}


### PR DESCRIPTION
forbedre på å kunne håndtere SEDs som ikke har nødvendige
data class i fagmodul skal fortsatt kunne håndteres.