### PR TITLE
Switch from Java 8 to Java 11

### DIFF
--- a/.github/workflows/bygg_alle_brancher.yml
+++ b/.github/workflows/bygg_alle_brancher.yml
@@ -16,6 +16,12 @@ jobs:
       - name: 'Pull repo'
         uses: actions/checkout@v1
 
+      # JAVA 11
+      - name: 'Java 11'
+        uses: actions/setup-java@v1.3.0
+        with:
+          java-version: 11
+
       # BYGGER DOCKER CONTAINER
       - name: 'Bygg'
         env:

--- a/.github/workflows/bygg_og_deploy_test.yml
+++ b/.github/workflows/bygg_og_deploy_test.yml
@@ -24,6 +24,12 @@ jobs:
       - name: 'Setter Image'
         run: echo "::set-env name=IMAGE::docker.pkg.github.com/${{ github.repository }}/eessi-pensjon-fagmodul:${{ env.DATE }}---${{ env.COMMIT_HASH }}"
 
+      # JAVA 11
+      - name: 'Java 11'
+        uses: actions/setup-java@v1.3.0
+        with:
+          java-version: 11
+
       # BYGGER DOCKER CONTAINER
       - name: 'Bygg og publiser docker image'
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM navikt/java:8-appdynamics
+FROM navikt/java:11-appdynamics
 
 COPY build/libs/eessi-fagmodul-*.jar /app/app.jar
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,21 +40,27 @@ apply plugin: "org.jetbrains.kotlin.plugin.spring"
 apply plugin: "org.jetbrains.kotlin.plugin.allopen"
 apply plugin: "org.springframework.boot"
 
+assert JavaVersion.current().isJava11Compatible(): "Java 11 or newer is required"
+
 group = 'no.nav.eessi'
 version = '0.0.1'
-sourceCompatibility = 1.8
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
 
 compileKotlin {
     kotlinOptions {
         freeCompilerArgs = ["-Xjsr305=strict"]
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 }
 
 compileTestKotlin {
     kotlinOptions {
         freeCompilerArgs = ["-Xjsr305=strict"]
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 }
 
@@ -132,6 +138,7 @@ dependencies {
     // Tjenestespesifikasjoner
     implementation("no.nav.tjenestespesifikasjoner:person-v3-tjenestespesifikasjon:1.2020.01.30-14.36-cdf257baea96")
     xsd("no.nav.tjenestespesifikasjoner:pensjonsinformasjon-v1-tjenestespesifikasjon:1.2020.01.30-14.36-cdf257baea96")
+    implementation("com.sun.xml.ws:jaxws-ri:2.3.2")
 
     jaxb ('org.glassfish.jaxb:jaxb-xjc:2.3.2')
     jaxb ('org.glassfish.jaxb:jaxb-runtime:2.3.2')


### PR DESCRIPTION
When this is applied you need to change the JDK you use for development
from Java 8 to at least Java 11.

See: https://confluence.adeo.no/x/MlrfFQ