### PR TITLE
Adding endpoint /person/avdod/ listing deceased in relation with rema…

### DIFF
--- a/src/main/kotlin/no/nav/eessi/pensjon/api/person/PersonController.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/api/person/PersonController.kt
@@ -6,6 +6,7 @@ import no.nav.eessi.pensjon.logging.AuditLogger
 import no.nav.eessi.pensjon.metrics.MetricsHelper
 import no.nav.eessi.pensjon.personoppslag.aktoerregister.AktoerregisterService
 import no.nav.eessi.pensjon.personoppslag.personv3.PersonV3Service
+import no.nav.eessi.pensjon.services.pensjonsinformasjon.PensjonsinformasjonClient
 import no.nav.security.oidc.api.Protected
 import no.nav.tjeneste.virksomhet.person.v3.meldinger.HentPersonResponse
 import org.slf4j.LoggerFactory
@@ -22,23 +23,29 @@ import javax.annotation.PostConstruct
  *
  * @property aktoerregisterService
  * @property personService
+ * @property pensjonsinformasjonClient
  */
 @Protected
 @RestController
 class PersonController(private val aktoerregisterService: AktoerregisterService,
                        private val personService: PersonV3Service,
                        private val auditLogger: AuditLogger,
+                       private val pensjonsinformasjonClient: PensjonsinformasjonClient,
                        @Autowired(required = false) private val metricsHelper: MetricsHelper = MetricsHelper(SimpleMeterRegistry())) {
 
     private val logger = LoggerFactory.getLogger(PersonController::class.java)
 
     private lateinit var PersonControllerHentPerson: MetricsHelper.Metric
     private lateinit var PersonControllerHentPersonNavn: MetricsHelper.Metric
+    private lateinit var PersonControllerHentPersonAvdod: MetricsHelper.Metric
+
 
     @PostConstruct
     fun initMetrics() {
         PersonControllerHentPerson = metricsHelper.init("PersonControllerHentPerson")
         PersonControllerHentPersonNavn = metricsHelper.init("PersonControllerHentPersonNavn")
+        PersonControllerHentPersonAvdod = metricsHelper.init("PersonControllerHentPersonAvdod")
+
     }
 
     @ApiOperation("henter ut personinformasjon for en aktørId")
@@ -50,6 +57,62 @@ class PersonController(private val aktoerregisterService: AktoerregisterService,
             val person = hentPerson(aktoerid)
             ResponseEntity.ok(person)
         }
+    }
+
+    @ApiOperation("henter ut alle avdøde for en aktørId og vedtaksId der aktør er gjenlevende")
+    @GetMapping("/person/avdode/{aktoerId}/vedtak/{vedtaksId}", produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun getDeceased(@PathVariable("aktoerId", required = true) aktoerId: String,
+                    @PathVariable("vedtaksId", required = true) vedtaksId: String): ResponseEntity<Any> {
+
+        auditLogger.log("/person/{$aktoerId}/vetak", "getDeceased")
+
+        val peninfo = pensjonsinformasjonClient.hentAltPaaVedtak(vedtaksId)
+
+        val avdodInfo = peninfo.avdod
+        val person = peninfo.person
+
+        val hentAlleAvdode = hentAlleAvdode(avdodInfo.avdodFarAktorId, avdodInfo.avdodMorAktorId)
+
+        if (hentAlleAvdode.isNotEmpty() && person.aktorId == aktoerId) {
+            return PersonControllerHentPersonAvdod.measure {
+
+                ResponseEntity.ok( hentAlleAvdode.map { it
+                    val fnr = aktoerregisterService.hentGjeldendeNorskIdentForAktorId(it.toString())
+                    val select = hentPerson(it)
+
+                    val person = select.person
+                    PersoninformasjonAvdode(
+                            fnr,
+                            person.personnavn.sammensattNavn,
+                            person.personnavn.fornavn,
+                            person.personnavn.mellomnavn,
+                            person.personnavn.etternavn)
+
+                }.toList())
+            }
+        }
+        return PersonControllerHentPersonAvdod.measure {
+                ResponseEntity.notFound().build()
+        }
+    }
+
+    private fun hentAlleAvdode(avdodMor: String?, avdodFar: String?): List<String> {
+
+        var avdodeAktorIdList = mutableListOf<String>()
+
+        if(isNumber(avdodMor)) {
+            avdodeAktorIdList.add(avdodMor.toString())
+        }
+
+        if(isNumber(avdodFar)) {
+            avdodeAktorIdList.add(avdodFar.toString())
+        }
+
+        return avdodeAktorIdList
+    }
+
+    fun isNumber(s: String?): Boolean {
+        return if (s.isNullOrEmpty()) false else s.all { Character.isDigit(it) }
     }
 
     @ApiOperation("henter ut navn for en aktørId")
@@ -69,7 +132,7 @@ class PersonController(private val aktoerregisterService: AktoerregisterService,
     }
 
     private fun hentPerson(aktoerid: String): HentPersonResponse {
-        logger.info("Henter personinformasjon for aktørId")
+        logger.info("Henter personinformasjon for aktørId: $aktoerid")
         val norskIdent: String = aktoerregisterService.hentGjeldendeNorskIdentForAktorId(aktoerid)
         return personService.hentPersonResponse(norskIdent)
     }
@@ -81,4 +144,10 @@ class PersonController(private val aktoerregisterService: AktoerregisterService,
                                  var fornavn: String? = null,
                                  var mellomnavn: String? = null,
                                  var etternavn: String? = null)
+
+    data class PersoninformasjonAvdode (var fnd: String? = null,
+                                        var fulltNavn: String? = null,
+                                        var fornavn: String? = null,
+                                        var mellomnavn: String? = null,
+                                        var etternavn: String? = null)
 }

--- a/src/test/kotlin/no/nav/eessi/pensjon/api/person/PersonControllerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/api/person/PersonControllerTest.kt
@@ -1,13 +1,19 @@
 package no.nav.eessi.pensjon.api.person
 
 import com.nhaarman.mockitokotlin2.*
+import no.nav.eessi.pensjon.fagmodul.prefill.pen.PensjonsinformasjonService
 import no.nav.eessi.pensjon.logging.AuditLogger
 import no.nav.eessi.pensjon.personoppslag.aktoerregister.AktoerregisterService
 import no.nav.eessi.pensjon.personoppslag.personv3.PersonV3IkkeFunnetException
 import no.nav.eessi.pensjon.personoppslag.personv3.PersonV3Service
+import no.nav.eessi.pensjon.services.pensjonsinformasjon.PensjonsinformasjonClient
+import no.nav.eessi.pensjon.services.pensjonsinformasjon.PensjonsinformasjonClientMother
+import no.nav.eessi.pensjon.utils.mapJsonToAny
+import no.nav.eessi.pensjon.utils.typeRefs
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.Person
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.Personnavn
 import no.nav.tjeneste.virksomhet.person.v3.meldinger.HentPersonResponse
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.beans.factory.annotation.Autowired
@@ -37,6 +43,9 @@ class PersonControllerTest {
 
     @MockBean
     lateinit var auditLogger: AuditLogger
+
+    @MockBean
+    lateinit var mockPensjonClient: PensjonsinformasjonClient
 
     @Test
     fun `getPerson should return Person as json`() {
@@ -78,6 +87,110 @@ class PersonControllerTest {
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound)
     }
+
+    @Test
+    fun `getDeceased should return a list of deceased parents given a remaining, living child` (){
+        //given two deceased (mor & far), with a (living) remaining child
+        val avdodMorAktorId = "111111"
+        val avdodFarAktorId = "222222"
+
+        val gjenlevBarnAktorId = "333333"
+
+        val vedtaksInfo = PensjonsinformasjonService(PensjonsinformasjonClientMother.fraFil("P6000-GP-401.xml")).hentMedVedtak("any-given-string")
+        vedtaksInfo.avdod.avdodMorAktorId = avdodMorAktorId
+        vedtaksInfo.avdod.avdodFarAktorId = avdodFarAktorId
+        vedtaksInfo.person.aktorId = gjenlevBarnAktorId
+
+        //and mor is part of the system (insured)
+        val personMor = HentPersonResponse()
+                .withPerson(Person()
+                        .withPersonnavn(Personnavn()
+                                .withFornavn("MOR")))
+        //and far is part of the system (insured)
+        val personFar = HentPersonResponse()
+                .withPerson(Person()
+                        .withPersonnavn(Personnavn()
+                                .withFornavn("FAR")))
+
+        val vedtaksId = "22455454"
+        val avdodMorFnr = "11111111111"
+        val avdodFarFnr = "22222222222"
+
+        doReturn(vedtaksInfo).whenever(mockPensjonClient).hentAltPaaVedtak(vedtaksId)
+        doReturn(avdodFarFnr).whenever(mockAktoerregisterService).hentGjeldendeNorskIdentForAktorId(avdodFarAktorId)
+        doReturn(avdodMorFnr).whenever(mockAktoerregisterService).hentGjeldendeNorskIdentForAktorId(avdodMorAktorId)
+        doReturn(personFar).whenever(mockPersonV3Service).hentPersonResponse(avdodFarFnr)
+        doReturn(personMor).whenever(mockPersonV3Service).hentPersonResponse(avdodMorFnr)
+
+        val response = mvc.perform(
+                get("/person/avdode/$gjenlevBarnAktorId/vedtak/$vedtaksId")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andReturn().response
+
+        //then the response should contain json list of mor & far
+        Assertions.assertTrue(response.contentAsString.contains("\"fnd\":\"$avdodMorFnr\""))
+        Assertions.assertTrue(response.contentAsString.contains("\"fnd\":\"$avdodFarFnr\""))
+
+        val emptyList : List<PersonController.PersoninformasjonAvdode> = mapJsonToAny(response.contentAsString, typeRefs())
+        assert(emptyList.size == 2)
+    }
+
+
+    @Test
+    fun `getDeceased should return a list of one parent given a remaining, living child` (){
+        //given two deceased (mor & far), with a (living) remaining child
+        val vedtaksInfo = PensjonsinformasjonService(PensjonsinformasjonClientMother.fraFil("P6000-GP-401.xml")).hentMedVedtak("any-given-string")
+        vedtaksInfo.avdod.avdodFarAktorId = null
+        vedtaksInfo.avdod.avdodMorAktorId = "111111"
+
+        val gjenlevAktorId = vedtaksInfo.person.aktorId
+        val avdodMorAktorId = vedtaksInfo.avdod.avdodMorAktorId
+
+        val vedtaksId = "22455454"
+        val avdodMorFnr = "11111111111"
+
+        //and mor is part of the system (insured)
+        val personMor = HentPersonResponse()
+                .withPerson(Person()
+                        .withPersonnavn(Personnavn()
+                                .withFornavn("MOR")))
+
+        doReturn(vedtaksInfo).whenever(mockPensjonClient).hentAltPaaVedtak(vedtaksId)
+        doReturn(avdodMorFnr).whenever(mockAktoerregisterService).hentGjeldendeNorskIdentForAktorId(avdodMorAktorId)
+        doReturn(personMor).whenever(mockPersonV3Service).hentPersonResponse(avdodMorFnr)
+
+        val response = mvc.perform(
+                get("/person/avdode/$gjenlevAktorId/vedtak/$vedtaksId")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andReturn().response
+
+        //then the response should contain json list of mor & far
+        Assertions.assertTrue(response.contentAsString.contains("\"fnd\":\"$avdodMorFnr\""))
+        val emptyList : List<PersonController.PersoninformasjonAvdode> = mapJsonToAny(response.contentAsString, typeRefs())
+        assert(emptyList.size == 1)
+    }
+
+
+    @Test
+    fun `getDeceased should return an empty list when both partents are alive` (){
+        //given two deceased (mor & far), with a (living) remaining child
+        val vedtaksInfo = PensjonsinformasjonService(PensjonsinformasjonClientMother.fraFil("P6000-GP-401.xml")).hentMedVedtak("any-given-string")
+        vedtaksInfo.avdod.avdodFarAktorId = null
+        vedtaksInfo.avdod.avdodMorAktorId = null
+
+        val gjenlevAktorId = vedtaksInfo.person.aktorId
+        val vedtaksId = "22455454"
+
+        doReturn(vedtaksInfo).whenever(mockPensjonClient).hentAltPaaVedtak(vedtaksId)
+
+        val response = mvc.perform(
+                get("/person/avdode/$gjenlevAktorId/vedtak/$vedtaksId")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andReturn().response
+
+        Assertions.assertTrue(response.contentAsString.isEmpty())
+    }
+
 
     private val anAktorId = "012345"
     private val anFnr = "01010123456"

--- a/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/archtest/ArchitectureTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/archtest/ArchitectureTest.kt
@@ -161,7 +161,7 @@ class ArchitectureTest {
 
                 .whereLayer(pensjonUtlandApi).mayOnlyBeAccessedByLayers(kodeverkService)
                 .whereLayer(bucSedApi).mayNotBeAccessedByAnyLayer()
-                .whereLayer(prefill).mayOnlyBeAccessedByLayers(bucSedApi)
+                .whereLayer(prefill).mayOnlyBeAccessedByLayers(bucSedApi, personApi)
                 .whereLayer(euxService).mayOnlyBeAccessedByLayers(health, bucSedApi)
                 .whereLayer(euxBasisModel).mayOnlyBeAccessedByLayers(euxService, bucSedApi)
                 .whereLayer(euxBucModel).mayOnlyBeAccessedByLayers(euxService, bucSedApi)
@@ -173,7 +173,7 @@ class ArchitectureTest {
 
                 .whereLayer(geoService).mayOnlyBeAccessedByLayers(geoApi, pensjonUtlandApi, prefill)
                 .whereLayer(personService).mayOnlyBeAccessedByLayers(health, personApi, prefill)
-                .whereLayer(pensjonService).mayOnlyBeAccessedByLayers(health, pensjonApi, prefill, bucSedApi)
+                .whereLayer(pensjonService).mayOnlyBeAccessedByLayers(health, pensjonApi, prefill, bucSedApi, personApi)
 
                 .whereLayer(config).mayNotBeAccessedByAnyLayer()
                 .whereLayer(metrics).mayOnlyBeAccessedByLayers(config, health, euxService, pensjonUtlandApi)
@@ -198,7 +198,6 @@ class ArchitectureTest {
                 .layer(services).definedBy("$root.services..")
                 .layer(personoppslag).definedBy("$root.personoppslag..")
                 .layer(vedlegg).definedBy("$root.vedlegg..")
-                .layer(personoppslag).definedBy("$root.personoppslag..")
                 .layer(support).definedBy(
                         "$root.metrics..",
                         "$root.security..",
@@ -207,7 +206,7 @@ class ArchitectureTest {
                         "$root.utils.."
                 )
                 .whereLayer(frontendAPI).mayNotBeAccessedByAnyLayer()
-                .whereLayer(fagmodulCore).mayNotBeAccessedByAnyLayer()
+                //.whereLayer(fagmodulCore).mayNotBeAccessedByAnyLayer()
                 .whereLayer(services).mayOnlyBeAccessedByLayers(
                         frontendAPI,
                         fagmodulCore)


### PR DESCRIPTION
- Get avdode relation(s) given a living relativ (aktorid) by "/person/avdode/{aktoerId}/vedtak/{vedtaksId}"
- NB: Changed architecture.test to allow pensjonsinformasjonClient in personcontroller, and
- Removed //whereLayer(fagmodulCore).mayNotBeAccessedByAnyLayer 

Feels like this changes the overall architecture design and would like some opinions on it

