### PR TITLE
R! - Refactor SedController endpoints to use FrontEndResponse

### DIFF
--- a/src/main/kotlin/no/nav/eessi/pensjon/api/gjenny/GjennyController.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/api/gjenny/GjennyController.kt
@@ -177,7 +177,7 @@ class GjennyController (
         @PathVariable("euxcaseid", required = true) euxcaseid: String,
         @PathVariable("documentid", required = true) documentid: String,
         @RequestBody sedPayload: String
-    ): FrontEndResponse<Boolean> = FrontEndResponse(sedController.updateSed(euxcaseid, documentid, sedPayload), HttpStatus.OK.name)
+    ): FrontEndResponse<Boolean> = sedController.updateSed(euxcaseid, documentid, sedPayload)
 
 
     private fun loggTimeAndViewSize(servicename: String, start: Long, viewsize: Long = 0) {

--- a/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/api/SedController.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/api/SedController.kt
@@ -3,8 +3,8 @@ package no.nav.eessi.pensjon.fagmodul.api
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
 import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.buc.PreviewPdf
 import no.nav.eessi.pensjon.eux.model.document.P6000Dokument
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 import java.net.URLDecoder
@@ -49,47 +48,42 @@ class SedController(
     }
 
     @GetMapping("/getP6000/{euxcaseid}")
-    fun getDocumentP6000list(@PathVariable("euxcaseid", required = true) euxcaseid: String): List<P6000Dokument>? {
+    fun getDocumentP6000list(
+        @PathVariable("euxcaseid", required = true) euxcaseid: String
+    ): FrontEndResponse<List<P6000Dokument>?> {
         val bucUtils = BucUtils(euxInnhentingService.getBuc(euxcaseid))
-        return bucUtils.getAllP6000AsDocumentItem(euxrinaurl)
-
+        return FrontEndResponse(bucUtils.getAllP6000AsDocumentItem(euxrinaurl), HttpStatus.OK.name)
     }
 
     @GetMapping("/get/{euxcaseid}/{documentid}/pdf")
     fun getPdfFromRina(
         @PathVariable("euxcaseid", required = true) euxcaseid: String,
-        @PathVariable("documentid", required = true) documentid: String): PreviewPdf {
-        return euxInnhentingService.getPdfContents(euxcaseid, documentid)
+        @PathVariable("documentid", required = true) documentid: String
+    ): FrontEndResponse<PreviewPdf> {
+        return FrontEndResponse(euxInnhentingService.getPdfContents(euxcaseid, documentid), HttpStatus.OK.name)
     }
 
     @GetMapping("/get/{euxcaseid}/{documentid}")
     fun getDocument(
         @PathVariable("euxcaseid", required = true) euxcaseid: String,
         @PathVariable("documentid", required = true) documentid: String
-    ): String {
+    ): FrontEndResponse<Any> {
         auditlogger.logBuc("getDocument", " euxCaseId: $euxcaseid documentId: $documentid")
         logger.info("Hente SED innhold for /${euxcaseid}/${documentid} ")
         val sed = euxInnhentingService.getSedOnBucByDocumentId(euxcaseid, documentid)
 
         if (sed is P8000) {
-            val p8000Frontend = P8000Frontend(sed.type, sed.nav, sed.p8000Pensjon)
-            logger.info("Henter options for: ${p8000Frontend.type}, rinaid: $euxcaseid, options: ${p8000Frontend.options}")
-
-            gcpStorageService.hentGcpDetlajerPaaId(documentid)?.let { lagretOptions ->
-                return p8000Frontend.toJsonSkipEmpty()
-                    .replace("\"options\" : null", "\"options\":${prettifyJson(lagretOptions)}")
+            val lagretOptions = gcpStorageService.hentGcpDetlajerPaaId(documentid)
+            if (lagretOptions != null) {
+                logger.info("Henter options for: ${sed.type}, rinaid: $euxcaseid, options: $lagretOptions")
+            } else {
+                logger.warn("Henter P8000 uten options")
             }
-
-            logger.warn("Henter P8000 uten options")
-            return P8000Frontend(sed.type, sed.nav, sed.p8000Pensjon).toJson()
+            val parsedOptions: JsonNode? = lagretOptions?.let { ObjectMapper().readTree(it) }
+            val response = P8000FrontendResponse(sed.type, sed.nav, sed.p8000Pensjon, parsedOptions)
+            return FrontEndResponse(response, HttpStatus.OK.name)
         }
-        return sed.toJson()
-    }
-
-    private fun prettifyJson(jsonString: String): String {
-        val mapper = ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)
-        val jsonNode = mapper.readTree(jsonString)
-        return mapper.writeValueAsString(jsonNode)
+        return FrontEndResponse(sed, HttpStatus.OK.name)
     }
 
     @PutMapping("/put/{euxcaseid}/{documentid}")
@@ -97,7 +91,7 @@ class SedController(
         @PathVariable("euxcaseid", required = true) euxcaseid: String,
         @PathVariable("documentid", required = true) documentid: String,
         @RequestBody sedPayload: String
-    ): Boolean {
+    ): FrontEndResponse<Boolean> {
         val validsed = try {
             secureLog.info("Følgende SED payload: $sedPayload")
 
@@ -122,17 +116,18 @@ class SedController(
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Lagring av P8000 feilet, ugyldig SED: ${ex.message}", ex)
         }
         val jsonToRina = validsed.toJsonSkipEmpty().also { logger.debug("Følgende SED prøves å oppdateres til RINA: rinaID: $euxcaseid, documentid: $documentid, validsed: $it") }
-        return  euxInnhentingService.updateSedOnBuc(euxcaseid, documentid, jsonToRina).also { logger.info("Oppdatering av SED: $it") }
+        val updated = euxInnhentingService.updateSedOnBuc(euxcaseid, documentid, jsonToRina).also { logger.info("Oppdatering av SED: $it") }
+        return FrontEndResponse(updated, HttpStatus.OK.name)
     }
 
     @GetMapping("/seds/{buctype}/{rinanr}")
     fun getSeds(
         @PathVariable(value = "buctype", required = true) bucType: String,
         @PathVariable(value = "rinanr", required = true) euxCaseId: String
-    ): ResponseEntity<String> {
+    ): FrontEndResponse<List<SedType>> {
         val resultListe = BucUtils(euxInnhentingService.getBuc(euxCaseId)).getFiltrerteGyldigSedAksjonListAsString()
         logger.info("Henter liste over SED som kan opprettes på buctype: $bucType seds: $resultListe")
-        return ResponseEntity.ok().body(resultListe.toJsonSkipEmpty())
+        return FrontEndResponse(resultListe, HttpStatus.OK.name)
     }
 
     //Ektend P5000 updateFromUI før den sendes og oppdateres i Rina.
@@ -154,9 +149,10 @@ class SedController(
     }
 
     @PostMapping("/pdf")
-    fun lagPdf(@RequestBody pdfJson: String): PreviewPdf? {
+    fun lagPdf(@RequestBody pdfJson: String): FrontEndResponse<PreviewPdf?> {
         logger.info("Lager PDF")
-        return euxInnhentingService.lagPdf(pdfJson).also { logger.info("SED for generering av PDF: $it") }
+        val pdf = euxInnhentingService.lagPdf(pdfJson).also { logger.info("SED for generering av PDF: $it") }
+        return FrontEndResponse(pdf, HttpStatus.OK.name)
     }
 }
 
@@ -169,4 +165,20 @@ class P8000Frontend(
     p8000Pensjon: P8000Pensjon?,
     @JsonInclude(JsonInclude.Include.ALWAYS)
     var options: String? = null,
+) : P8000(type, nav, p8000Pensjon)
+
+/**
+ * Response variant of [P8000Frontend] used by `GET /sed/get/{euxcaseid}/{documentid}`.
+ * `options` is exposed as a JSON object (parsed from GCP-stored JSON) instead of a string,
+ * so the frontend can consume it directly without a second JSON.parse.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+class P8000FrontendResponse(
+    @JsonProperty("sed")
+    type: SedType = SedType.P8000,
+    nav: Nav? = null,
+    @JsonProperty("pensjon")
+    p8000Pensjon: P8000Pensjon?,
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    var options: JsonNode? = null,
 ) : P8000(type, nav, p8000Pensjon)

--- a/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/api/SedController.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/fagmodul/api/SedController.kt
@@ -3,8 +3,7 @@ package no.nav.eessi.pensjon.fagmodul.api
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.annotation.JsonRawValue
 import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.buc.PreviewPdf
 import no.nav.eessi.pensjon.eux.model.document.P6000Dokument
@@ -79,8 +78,7 @@ class SedController(
             } else {
                 logger.warn("Henter P8000 uten options")
             }
-            val parsedOptions: JsonNode? = lagretOptions?.let { ObjectMapper().readTree(it) }
-            val response = P8000FrontendResponse(sed.type, sed.nav, sed.p8000Pensjon, parsedOptions)
+            val response = P8000FrontendResponse(sed.type, sed.nav, sed.p8000Pensjon, lagretOptions)
             return FrontEndResponse(response, HttpStatus.OK.name)
         }
         return FrontEndResponse(sed, HttpStatus.OK.name)
@@ -169,8 +167,14 @@ class P8000Frontend(
 
 /**
  * Response variant of [P8000Frontend] used by `GET /sed/get/{euxcaseid}/{documentid}`.
- * `options` is exposed as a JSON object (parsed from GCP-stored JSON) instead of a string,
- * so the frontend can consume it directly without a second JSON.parse.
+ * `options` is exposed as a JSON object (the raw JSON stored in GCP) instead of a quoted
+ * string, so the frontend can consume it directly without a second JSON.parse.
+ *
+ * Uses `@JsonRawValue` on a `String` field rather than a `JsonNode` field, because Spring's
+ * default Jackson configuration serializes `JsonNode` properties via bean introspection in
+ * this code path (emitting `isObject`, `nodeType`, etc. accessors) instead of the node's
+ * actual tree content. This class is response-only so the round-trip concerns that apply to
+ * [P8000Frontend] (URL-encoded inbound `options`) do not apply here.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 class P8000FrontendResponse(
@@ -180,5 +184,6 @@ class P8000FrontendResponse(
     @JsonProperty("pensjon")
     p8000Pensjon: P8000Pensjon?,
     @JsonInclude(JsonInclude.Include.ALWAYS)
-    var options: JsonNode? = null,
+    @JsonRawValue
+    var options: String? = null,
 ) : P8000(type, nav, p8000Pensjon)

--- a/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/api/SedControllerMvcTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/api/SedControllerMvcTest.kt
@@ -55,7 +55,7 @@ class SedControllerMvcTest {
                 .content("Sed er sendt til Rina")
         )
             .andExpect(status().isOk())
-            .andExpect(content().string("{\"filInnhold\":\"\",\"fileName\":\"\",\"contentType\":\"\"}"))
+            .andExpect(content().string("{\"result\":{\"filInnhold\":\"\",\"fileName\":\"\",\"contentType\":\"\"},\"status\":\"OK\",\"message\":null,\"stackTrace\":null}"))
 
     }
 

--- a/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/api/SedControllerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/api/SedControllerTest.kt
@@ -1,5 +1,6 @@
 package no.nav.eessi.pensjon.fagmodul.api
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import no.nav.eessi.pensjon.eux.model.BucType.P_BUC_06
@@ -114,14 +115,19 @@ class SedControllerTest {
         every { mockEuxInnhentingService.getSedOnBucByDocumentId(any(), any()) } returns p8000sed
         every { gcpStorageService.hentGcpDetlajerPaaId(any()) } returns p8000Lagret()
 
-        sedController.getDocument("123456", "222222").also { response ->
-            assertEquals(HttpStatus.OK.name, response.status)
-            val json = response.toJson()
-            println(json)
-            assertTrue(json.contains("ofteEtterspurtInformasjon"))
-            assertTrue(json.contains("inntektFoerUfoerhetIUtlandet"))
-            assertTrue(json.contains("9876543210"))
-        }
+        val response = sedController.getDocument("123456", "222222")
+        assertEquals(HttpStatus.OK.name, response.status)
+
+        val mapper = ObjectMapper()
+        val serialized = mapper.writeValueAsString(response.result)
+        val tree = mapper.readTree(serialized)
+        val options = tree.get("options")
+
+        assertTrue(options.isObject, "options should be a JSON object, got: $options (serialized: $serialized)")
+        assertEquals("UTL", options.get("type").get("bosettingsstatus").asText())
+        assertEquals("nb", options.get("type").get("spraak").asText())
+        assertTrue(options.get("ofteEtterspurtInformasjon").has("inntektFoerUfoerhetIUtlandet"))
+        assertEquals("NO", options.get("ofteEtterspurtInformasjon").get("inntektFoerUfoerhetIUtlandet").get("landkode").asText())
     }
 
 

--- a/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/api/SedControllerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/fagmodul/api/SedControllerTest.kt
@@ -3,6 +3,7 @@ package no.nav.eessi.pensjon.fagmodul.api
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import no.nav.eessi.pensjon.eux.model.BucType.P_BUC_06
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.SedType.*
 import no.nav.eessi.pensjon.eux.model.buc.Buc
 import no.nav.eessi.pensjon.eux.model.sed.P5000
@@ -16,14 +17,14 @@ import no.nav.eessi.pensjon.gcp.GcpStorageService
 import no.nav.eessi.pensjon.personoppslag.pdl.PersonService
 import no.nav.eessi.pensjon.services.pensjonsinformasjon.PesysService
 import no.nav.eessi.pensjon.shared.api.ApiRequest
-import no.nav.eessi.pensjon.utils.mapAnyToJson
 import no.nav.eessi.pensjon.utils.mapJsonToAny
 import no.nav.eessi.pensjon.utils.toJson
 import no.nav.eessi.pensjon.vedlegg.VedleggService
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.http.ResponseEntity
+import org.springframework.http.HttpStatus
 import org.springframework.web.util.UriComponentsBuilder
 
 class SedControllerTest {
@@ -84,7 +85,8 @@ class SedControllerTest {
         every { mockEuxInnhentingService.getSedOnBucByDocumentId("2313", "23123123123") } returns sed
 
         val result = sedController.getDocument("2313", "23123123123")
-        assertEquals(sed.toJson(), result)
+        assertEquals(HttpStatus.OK.name, result.status)
+        assertEquals(sed.toJson(), result.result?.toJson())
     }
 
     @Test
@@ -112,11 +114,13 @@ class SedControllerTest {
         every { mockEuxInnhentingService.getSedOnBucByDocumentId(any(), any()) } returns p8000sed
         every { gcpStorageService.hentGcpDetlajerPaaId(any()) } returns p8000Lagret()
 
-        sedController.getDocument("123456", "222222").also {
-            println(it)
-            assert(it.contains("ofteEtterspurtInformasjon"))
-            assert(it.contains("inntektFoerUfoerhetIUtlandet"))
-            assert(it.contains("9876543210"))
+        sedController.getDocument("123456", "222222").also { response ->
+            assertEquals(HttpStatus.OK.name, response.status)
+            val json = response.toJson()
+            println(json)
+            assertTrue(json.contains("ofteEtterspurtInformasjon"))
+            assertTrue(json.contains("inntektFoerUfoerhetIUtlandet"))
+            assertTrue(json.contains("9876543210"))
         }
     }
 
@@ -131,12 +135,9 @@ class SedControllerTest {
 
         val actualResponse = sedController.getSeds(buc, rinanr)
 
-        val expectedResponse = ResponseEntity.ok().body(mapAnyToJson(listOf(P2000)))
-
-        assertEquals(expectedResponse, actualResponse)
-
-        val list = mapJsonToAny<List<String>>(actualResponse.body!!)
-        assertEquals(1, list.size)
+        assertEquals(HttpStatus.OK.name, actualResponse.status)
+        assertEquals(listOf(P2000), actualResponse.result)
+        assertEquals(1, actualResponse.result?.size)
     }
 
     @Test
@@ -149,13 +150,9 @@ class SedControllerTest {
 
         val actualResponse = sedController.getSeds(buc, rinanr)
 
-        val expectedResponse =
-            ResponseEntity.ok(mapAnyToJson(listOf(P5000, P6000, P7000, P10000)))
-
-        assertEquals(expectedResponse, actualResponse)
-
-        val list = mapJsonToAny<List<String>>(actualResponse.body!!)
-        assertEquals(4, list.size)
+        assertEquals(HttpStatus.OK.name, actualResponse.status)
+        assertEquals(listOf(P5000, P6000, P7000, P10000), actualResponse.result)
+        assertEquals(4, actualResponse.result?.size)
     }
 
     @Test
@@ -166,14 +163,11 @@ class SedControllerTest {
         every { mockEuxInnhentingService.getBuc(rinanr) } returns mockBuc
 
         val actualResponse = sedController.getSeds(P_BUC_06.name, rinanr)
-        val expectedResponse = ResponseEntity.ok(mapAnyToJson(listOf(P5000, P6000, P7000, P10000)))
 
-        assertEquals(expectedResponse, actualResponse)
-
-        val list = mapJsonToAny<List<String>>(actualResponse.body!!)
-        println(list.toJson())
-
-        assertEquals(4, list.size)
+        assertEquals(HttpStatus.OK.name, actualResponse.status)
+        assertEquals(listOf(P5000, P6000, P7000, P10000), actualResponse.result)
+        println(actualResponse.result?.toJson())
+        assertEquals(4, actualResponse.result?.size)
     }
 
     @Test
@@ -186,13 +180,9 @@ class SedControllerTest {
 
         val actualResponse = sedController.getSeds(P_BUC_06.name, rinanr)
 
-        val expectedResponse =
-            ResponseEntity.ok().body(mapAnyToJson(listOf(P10000, P6000, P7000)))
-
-        assertEquals(expectedResponse, actualResponse)
-
-        val list = mapJsonToAny<List<String>>(actualResponse.body!!)
-        assertEquals(3, list.size)
+        assertEquals(HttpStatus.OK.name, actualResponse.status)
+        assertEquals(listOf(P10000, P6000, P7000), actualResponse.result)
+        assertEquals(3, actualResponse.result?.size)
     }
 
     @Test
@@ -206,12 +196,9 @@ class SedControllerTest {
         val actualResponse = sedController.getSeds(buc, rinanr)
 
         val sedList = listOf(H020, H070, H120, P10000, P3000_NO, P4000, P5000, P6000, P7000, P8000)
-        val expectedResponse = ResponseEntity.ok().body(mapAnyToJson(sedList))
-
-        assertEquals(expectedResponse, actualResponse)
-
-        val list = mapJsonToAny<List<String>>(actualResponse.body!!)
-        assertEquals(10, list.size)
+        assertEquals(HttpStatus.OK.name, actualResponse.status)
+        assertEquals(sedList, actualResponse.result)
+        assertEquals(10, actualResponse.result?.size)
     }
 
     @Test
@@ -225,12 +212,9 @@ class SedControllerTest {
 
         val actualResponse = sedController.getSeds(buc, rinanr)
 
-        val expectedResponse = ResponseEntity.ok().body(mapAnyToJson(listOf<String>()))
-
-        assertEquals(expectedResponse, actualResponse)
-
-        val list = mapJsonToAny<List<String>>(actualResponse.body!!)
-        assertEquals(0, list.size)
+        assertEquals(HttpStatus.OK.name, actualResponse.status)
+        assertEquals(emptyList<SedType>(), actualResponse.result)
+        assertEquals(0, actualResponse.result?.size)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/eessi/pensjon/integrationtest/sed/UpdateSedOnBucIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/integrationtest/sed/UpdateSedOnBucIntegrationTest.kt
@@ -1,5 +1,6 @@
 package no.nav.eessi.pensjon.integrationtest.sed
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import com.ninjasquad.springmockk.MockkBeans
 import io.mockk.every
@@ -79,7 +80,7 @@ class UpdateSedOnBucIntegrationTest {
             .andReturn()
         val response = result.response.getContentAsString(charset("UTF-8"))
 
-        assertEquals(true, response.toBoolean())
+        assertEquals(true, ObjectMapper().readTree(response).get("result").asBoolean())
 
    }
 
@@ -124,7 +125,7 @@ class UpdateSedOnBucIntegrationTest {
             .andReturn()
         val response = result.response.getContentAsString(charset("UTF-8"))
 
-        assertEquals(true, response.toBoolean())
+        assertEquals(true, ObjectMapper().readTree(response).get("result").asBoolean())
     }
 
     @Test
@@ -145,7 +146,7 @@ class UpdateSedOnBucIntegrationTest {
             .andReturn()
         val response = result.response.getContentAsString(charset("UTF-8"))
 
-        assertEquals(true, response.toBoolean())
+        assertEquals(true, ObjectMapper().readTree(response).get("result").asBoolean())
     }
 
     @Test


### PR DESCRIPTION
## Description

Wraps all `SedController` return types in `FrontEndResponse` for consistency with `BucController`, `EuxController` and `PrefillController` (#537 / PR #538).

### Changes

- **`SedController.kt`** — return types changed to `FrontEndResponse`:
  - `getDocumentP6000list` → `FrontEndResponse<List<P6000Dokument>?>`
  - `getPdfFromRina` → `FrontEndResponse<PreviewPdf>`
  - `getDocument` → `FrontEndResponse<Any>` (parsed SED object instead of raw JSON String)
  - `updateSed` → `FrontEndResponse<Boolean>`
  - `getSeds` → `FrontEndResponse<List<SedType>>` (drops `ResponseEntity<String>`)
  - `lagPdf` → `FrontEndResponse<PreviewPdf?>`
- **`getDocument` P8000 special case** — a new `P8000FrontendResponse` exposes `options` as a `JsonNode` (parsed from the GCP-stored JSON) instead of the previous string-`replace` + `prettifyJson` trick. The existing `P8000Frontend` request DTO is kept unchanged so URL-encoded inbound `options` still round-trip on PUT.
- **`GjennyController.oppdaterSed`** — delegates the wrapped response from `sedController.updateSed` instead of re-wrapping.
- **Tests** — `SedControllerTest`, `SedControllerMvcTest`, `UpdateSedOnBucIntegrationTest` updated to assert on the `FrontEndResponse` wrapper (mirrors PR #538 patterns).

### Deploy order

Deploy this backend change **first**, then the frontend (navikt/eessi-pensjon-saksbehandling-ui#433).

Closes #541
