### PR TITLE
Fjerner trailing slash i kall til saf

### DIFF
--- a/src/main/kotlin/no/nav/eessi/pensjon/vedlegg/client/SafClient.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/vedlegg/client/SafClient.kt
@@ -49,7 +49,7 @@ class SafClient(private val safGraphQlOidcRestTemplate: RestTemplate,
                 val headers = HttpHeaders()
                 headers.contentType = MediaType.APPLICATION_JSON
                 val httpEntity = HttpEntity(genererQuery(aktoerId), headers)
-                val response = safGraphQlOidcRestTemplate.exchange("/",
+                val response = safGraphQlOidcRestTemplate.exchange("",
                         HttpMethod.POST,
                         httpEntity,
                         String::class.java)

--- a/src/test/kotlin/no/nav/eessi/pensjon/integrationtest/buc/BucControllerIT.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/integrationtest/buc/BucControllerIT.kt
@@ -112,7 +112,7 @@ internal class BucControllerIT: BucBaseTest() {
         //saf (vedlegg meta) gjenlevende
         val httpEntity = dummyHeader(dummySafReqeust(GJENLEV_AKTOERID))
 
-        every { restSafTemplate.exchange(eq("/"), HttpMethod.POST, httpEntity, String::class.java) } returns ResponseEntity.ok().body(  dummySafMetaResponse() )
+        every { restSafTemplate.exchange(eq(""), HttpMethod.POST, httpEntity, String::class.java) } returns ResponseEntity.ok().body(  dummySafMetaResponse() )
 
 
         val result = mockMvc.perform(get("/buc/rinasaker/$GJENLEV_AKTOERID/saknr/null/avdod/$AVDOD_FNR")
@@ -143,7 +143,7 @@ internal class BucControllerIT: BucBaseTest() {
 
         //saf (vedlegg meta) gjenlevende
         val httpEntity = dummyHeader(dummySafReqeust(GJENLEV_AKTOERID))
-        every { restSafTemplate.exchange("/", HttpMethod.POST, httpEntity, String::class.java) } returns ResponseEntity.ok().body(  dummySafMetaResponse() )
+        every { restSafTemplate.exchange("", HttpMethod.POST, httpEntity, String::class.java) } returns ResponseEntity.ok().body(  dummySafMetaResponse() )
         //buc02 sed
         val rinabucdocumentidpath = "/buc/1010/sed/1"
         every { euxNavIdentRestTemplate.exchange( rinabucdocumentidpath, HttpMethod.GET, null, String::class.java) } returns ResponseEntity.ok().body( sedjson )
@@ -196,7 +196,7 @@ internal class BucControllerIT: BucBaseTest() {
 
         //saf (vedlegg meta) gjenlevende
         val httpEntity = dummyHeader(dummySafReqeust(GJENLEV_AKTOERID))
-        every { restSafTemplate.exchange(eq("/"), eq(HttpMethod.POST), eq(httpEntity), eq(String::class.java)) } returns ResponseEntity.ok().body(  dummySafMetaResponseMedRina("1010"))
+        every { restSafTemplate.exchange(eq(""), eq(HttpMethod.POST), eq(httpEntity), eq(String::class.java)) } returns ResponseEntity.ok().body(  dummySafMetaResponseMedRina("1010"))
 
         val rinaSafUrl = dummyRinasakUrl(euxCaseId =  "1010")
         every { euxNavIdentRestTemplate.exchange( eq(rinaSafUrl.toUriString()), eq(HttpMethod.GET), null, eq(String::class.java)) } returns ResponseEntity.ok().body( rinaSakerBuc02.toJson())
@@ -224,7 +224,7 @@ internal class BucControllerIT: BucBaseTest() {
         JSONAssert.assertEquals(responseBodyResult.result?.toJson(), bucViewResponse, false)
 
         verify (exactly = 1) { euxNavIdentRestTemplate.exchange("/rinasaker?fødselsnummer=01010100001&status=\"open\"", HttpMethod.GET, null, String::class.java) }
-        verify (exactly = 1) { restSafTemplate.exchange("/", HttpMethod.POST, httpEntity, String::class.java) }
+        verify (exactly = 1) { restSafTemplate.exchange("", HttpMethod.POST, httpEntity, String::class.java) }
 
     }
 
@@ -259,7 +259,7 @@ internal class BucControllerIT: BucBaseTest() {
         //saf (vedlegg meta) gjenlevende
         val httpEntity = dummyHeader(dummySafReqeust(GJENLEV_AKTOERID))
 
-        every { restSafTemplate.exchange(eq("/"), eq(HttpMethod.POST), eq(httpEntity), eq(String::class.java)) } returns  ResponseEntity.ok().body(  dummySafMetaResponseMedRina("1010") )
+        every { restSafTemplate.exchange(eq(""), eq(HttpMethod.POST), eq(httpEntity), eq(String::class.java)) } returns  ResponseEntity.ok().body(  dummySafMetaResponseMedRina("1010") )
 
         //buc02 sed
         val rinabucdocumentidpath = "/buc/1010/sed/1"
@@ -282,7 +282,7 @@ internal class BucControllerIT: BucBaseTest() {
         val svar = mapJsonToAny<FrontEndResponse<List<EuxInnhentingService.BucView>>>(response)
         verify (exactly = 1) { euxNavIdentRestTemplate.exchange("/rinasaker?fødselsnummer=01010100001&status=\"open\"", HttpMethod.GET, null, String::class.java) }
         verify (exactly = 1) { euxNavIdentRestTemplate.exchange("/buc/1010", HttpMethod.GET, null, String::class.java) }
-        verify (exactly = 1) { restSafTemplate.exchange("/", HttpMethod.POST, httpEntity, String::class.java) }
+        verify (exactly = 1) { restSafTemplate.exchange("", HttpMethod.POST, httpEntity, String::class.java) }
         assertTrue { response.contains(AVDOD_FNR) }
         JSONAssert.assertEquals(svar.result?.toJson(), bucViewResponse, false)
 
@@ -308,7 +308,7 @@ internal class BucControllerIT: BucBaseTest() {
 
         //saf (vedlegg meta) gjenlevende
         val httpEntity = dummyHeader(dummySafReqeust(GJENLEV_AKTOERID))
-        every { restSafTemplate.exchange(eq("/"), eq(HttpMethod.POST), eq(httpEntity), eq(String::class.java)) } returns ResponseEntity.ok().body(  dummySafMetaResponseMedRina("2020") )
+        every { restSafTemplate.exchange(eq(""), eq(HttpMethod.POST), eq(httpEntity), eq(String::class.java)) } returns ResponseEntity.ok().body(  dummySafMetaResponseMedRina("2020") )
         every { gcpStorageService.gjennySakFinnes(any()) } returns false
 
         val expected = """
@@ -330,7 +330,7 @@ internal class BucControllerIT: BucBaseTest() {
         val svar = mapJsonToAny<FrontEndResponse<List<EuxInnhentingService.BucView>>>(response)
 
         verify (exactly = 1) { euxNavIdentRestTemplate.exchange("/rinasaker?fødselsnummer=01010100001&status=\"open\"", HttpMethod.GET, null, String::class.java) }
-        verify (exactly = 1) { restSafTemplate.exchange(eq("/") , HttpMethod.POST, eq(httpEntity), String::class.java) }
+        verify (exactly = 1) { restSafTemplate.exchange(eq("") , HttpMethod.POST, eq(httpEntity), String::class.java) }
         JSONAssert.assertEquals(svar.result?.toJson(), expected, false)
     }
 

--- a/src/test/kotlin/no/nav/eessi/pensjon/integrationtest/buc/BucViewDetaljIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/integrationtest/buc/BucViewDetaljIntegrationTest.kt
@@ -264,7 +264,7 @@ internal class BucViewDetaljIntegrationTest: BucBaseTest() {
 
         //saf (sikker arkiv fasade) (vedlegg meta) gjenlevende
         val httpEntity = dummyHeader(dummySafReqeust(AKTOERID))
-        every { safGraphQlOidcRestTemplate.exchange(eq("/"), eq(HttpMethod.POST), eq(httpEntity), eq(String::class.java)) } returns ResponseEntity.ok().body(  dummySafMetaResponseMedRina( "5010", "344000" ) )
+        every { safGraphQlOidcRestTemplate.exchange(eq(""), eq(HttpMethod.POST), eq(httpEntity), eq(String::class.java)) } returns ResponseEntity.ok().body(  dummySafMetaResponseMedRina( "5010", "344000" ) )
 
         every { euxNavIdentRestTemplate.exchange( "/buc/5010", HttpMethod.GET, null, String::class.java) } returns ResponseEntity.ok().body( Buc(id = "5010", processDefinitionName = "P_BUC_02").toJson() )
         every { euxNavIdentRestTemplate.exchange("/buc/344000", HttpMethod.GET, null, String::class.java) } returns ResponseEntity.ok().body( Buc(id = "344000", processDefinitionName = "P_BUC_03").toJson() )
@@ -281,7 +281,7 @@ internal class BucViewDetaljIntegrationTest: BucBaseTest() {
         val responseBodyResult = mapJsonToBucViewResponse(response)
 
         //data og spurt eux
-        verify (exactly = 1) { safGraphQlOidcRestTemplate.exchange("/", HttpMethod.POST, httpEntity, String::class.java) }
+        verify (exactly = 1) { safGraphQlOidcRestTemplate.exchange("", HttpMethod.POST, httpEntity, String::class.java) }
 
         val expected = """
             [{"euxCaseId":"5010","buctype":"P_BUC_02","aktoerId":"1123123123123123","saknr":"1203201322","avdodFnr":"6789567890000","kilde":"SAF"},
@@ -300,7 +300,7 @@ internal class BucViewDetaljIntegrationTest: BucBaseTest() {
 
         //saf (sikker arkiv fasade) (vedlegg meta) gjenlevende
         val httpEntity = dummyHeader(dummySafReqeust(AKTOERID))
-        every { safGraphQlOidcRestTemplate.exchange(eq("/"), eq(HttpMethod.POST), eq(httpEntity), eq(String::class.java)) } returns ResponseEntity.ok().body(  dummySafMetaResponseMedRina( "5195021", "5922554" ) )
+        every { safGraphQlOidcRestTemplate.exchange(eq(""), eq(HttpMethod.POST), eq(httpEntity), eq(String::class.java)) } returns ResponseEntity.ok().body(  dummySafMetaResponseMedRina( "5195021", "5922554" ) )
 
         //gjenlevende rinasak
         every { euxNavIdentRestTemplate.exchange("/rinasaker?fødselsnummer=1234567890000&status=\"open\"", HttpMethod.GET, null, String::class.java) } .answers( FunctionAnswer { Thread.sleep(250);  ResponseEntity.ok().body( listOf(dummyRinasak("5195021", "P_BUC_05") ).toJson() ) } )
@@ -320,7 +320,7 @@ internal class BucViewDetaljIntegrationTest: BucBaseTest() {
         val responseBody = mapJsonToBucViewResponse(response)
 
         verify (exactly = 1) { euxNavIdentRestTemplate.exchange("/rinasaker?fødselsnummer=1234567890000&status=\"open\"", HttpMethod.GET, null, String::class.java) }
-        verify (exactly = 1) { safGraphQlOidcRestTemplate.exchange("/", HttpMethod.POST, httpEntity, String::class.java) }
+        verify (exactly = 1) { safGraphQlOidcRestTemplate.exchange("", HttpMethod.POST, httpEntity, String::class.java) }
 
         val expected = """
                 [{"euxCaseId":"5195021","buctype":"P_BUC_05","aktoerId":"1123123123123123","saknr":"1203201322","avdodFnr":null,"kilde":"BRUKER"},
@@ -337,7 +337,7 @@ internal class BucViewDetaljIntegrationTest: BucBaseTest() {
 
         //saf (sikker arkiv fasade) (vedlegg meta) gjenlevende
         val httpEntity = dummyHeader(dummySafReqeust(AKTOERID))
-        every { safGraphQlOidcRestTemplate.exchange(eq("/"), eq(HttpMethod.POST), eq(httpEntity), eq(String::class.java)) } returns ResponseEntity.ok().body(  dummySafMetaResponseMedRina( "5195021", "5922554" ) )
+        every { safGraphQlOidcRestTemplate.exchange(eq(""), eq(HttpMethod.POST), eq(httpEntity), eq(String::class.java)) } returns ResponseEntity.ok().body(  dummySafMetaResponseMedRina( "5195021", "5922554" ) )
 
         //gjenlevende rinasak
         every { euxNavIdentRestTemplate.exchange("/rinasaker?fødselsnummer=1234567890000&status=\"open\"", HttpMethod.GET, null, String::class.java) } .answers( FunctionAnswer { Thread.sleep(250);  ResponseEntity.ok().body( listOf(dummyRinasak("5195021", "P_BUC_05") ).toJson() ) } )
@@ -360,7 +360,7 @@ internal class BucViewDetaljIntegrationTest: BucBaseTest() {
         val responseBody = mapJsonToBucViewResponse(response)
 
         verify (exactly = 1) { euxNavIdentRestTemplate.exchange("/rinasaker?fødselsnummer=1234567890000&status=\"open\"", HttpMethod.GET, null, String::class.java) }
-        verify (exactly = 1) { safGraphQlOidcRestTemplate.exchange("/", HttpMethod.POST, httpEntity, String::class.java) }
+        verify (exactly = 1) { safGraphQlOidcRestTemplate.exchange("", HttpMethod.POST, httpEntity, String::class.java) }
 
         val expected = """
                 [{"euxCaseId":"5195021","buctype":"P_BUC_05","aktoerId":"1123123123123123","saknr":"100001000","avdodFnr":null,"kilde":"BRUKER"},
@@ -377,7 +377,7 @@ internal class BucViewDetaljIntegrationTest: BucBaseTest() {
 
         //saf (sikker arkiv fasade) (vedlegg meta) gjenlevende
         val httpEntity = dummyHeader(dummySafReqeust(AKTOERID))
-        every { safGraphQlOidcRestTemplate.exchange(eq("/"), eq(HttpMethod.POST), eq(httpEntity), eq(String::class.java)) } returns ResponseEntity.ok().body( dummySafMetaResponse() )
+        every { safGraphQlOidcRestTemplate.exchange(eq(""), eq(HttpMethod.POST), eq(httpEntity), eq(String::class.java)) } returns ResponseEntity.ok().body( dummySafMetaResponse() )
 
         //gjenlevende rinasak
         val rinaSakerBuc = listOf(dummyRinasak("3010", "P_BUC_01"), dummyRinasak("75312", "P_BUC_03"))
@@ -399,7 +399,7 @@ internal class BucViewDetaljIntegrationTest: BucBaseTest() {
         val responseBody = mapJsonToBucViewResponse(response)
 
         verify (exactly = 1) { euxNavIdentRestTemplate.exchange("/rinasaker?fødselsnummer=1234567890000&status=\"open\"", HttpMethod.GET, null, String::class.java) }
-        verify (exactly = 1) { safGraphQlOidcRestTemplate.exchange("/", HttpMethod.POST, httpEntity, String::class.java) }
+        verify (exactly = 1) { safGraphQlOidcRestTemplate.exchange("", HttpMethod.POST, httpEntity, String::class.java) }
 
         val expected = """
             [{"euxCaseId":"3010","aktoerId":"1123123123123123","saknr":"100001000","avdodFnr":null},{"euxCaseId":"75312","aktoerId":"1123123123123123","saknr":"100001000","avdodFnr":null}]
@@ -412,7 +412,7 @@ internal class BucViewDetaljIntegrationTest: BucBaseTest() {
     @Test
     fun `Gitt at vi får inn en ikke migrert rinasak i metadata fra saf og fra rina saa skal denne fltreres vekk i begge view`() {
         every { personService.hentIdent(FOLKEREGISTERIDENT, AktoerId(AKTOERID)) } returns NorskIdent(FNR)
-        every { safGraphQlOidcRestTemplate.exchange(eq("/"), eq(HttpMethod.POST), eq(dummyHeader(dummySafReqeust(AKTOERID))), eq(String::class.java)) } returns
+        every { safGraphQlOidcRestTemplate.exchange(eq(""), eq(HttpMethod.POST), eq(dummyHeader(dummySafReqeust(AKTOERID))), eq(String::class.java)) } returns
                 ResponseEntity.ok().body(  dummySafMetaResponseMedRina("9859667") )
 
         val rinaSakerBuc = listOf(dummyRinasak("3010", "P_BUC_01"), dummyRinasak("75312", "P_BUC_03"))


### PR DESCRIPTION
Hei, nyere versjoner av spring boot tillater ikke trailing slash per default. Vi har litt custom oppsett for å tillate det men fjerner det etter at alle klienter har endret

Endringen burde gjøre slik at saf kalles med `/graphql` og ikke `/graphql/`