### PR TITLE
F!- Bruker FrontEndResponse i PensjonController

### DIFF
--- a/src/main/kotlin/no/nav/eessi/pensjon/api/pensjon/PensjonController.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/api/pensjon/PensjonController.kt
@@ -1,12 +1,10 @@
 package no.nav.eessi.pensjon.api.pensjon
 
+import no.nav.eessi.pensjon.fagmodul.api.FrontEndResponse
 import no.nav.eessi.pensjon.logging.AuditLogger
 import no.nav.eessi.pensjon.metrics.MetricsHelper
 import no.nav.eessi.pensjon.services.pensjonsinformasjon.EessiPensjonSak
 import no.nav.eessi.pensjon.services.pensjonsinformasjon.PesysService
-import no.nav.eessi.pensjon.utils.errorBody
-import no.nav.eessi.pensjon.utils.mapAnyToJson
-import no.nav.eessi.pensjon.utils.toJson
 import no.nav.eessi.pensjon.utils.toJsonSkipEmpty
 import no.nav.security.token.support.core.api.Protected
 import org.slf4j.LoggerFactory
@@ -48,18 +46,22 @@ class PensjonController(
      * Brukes for å hente saktype fra frontend / EP
      */
     @GetMapping("/saktype/{sakId}/{aktoerId}")
-    fun hentPensjonSakType(@PathVariable("sakId", required = true) sakId: String, @PathVariable("aktoerId", required = true) aktoerId: String): ResponseEntity<String>? {
+    fun hentPensjonSakType(@PathVariable("sakId", required = true) sakId: String, @PathVariable("aktoerId", required = true) aktoerId: String): ResponseEntity<FrontEndResponse<Pensjontype>> {
         auditlogger.log("hentPensjonSakType", aktoerId)
 
         return pensjonControllerHentSakType.measure {
             try {
                 logger.info("Henter sakstype på $sakId / $aktoerId")
                 pesysService.hentSaktype(sakId)?.let {
-                    ResponseEntity.ok(mapAnyToJson(Pensjontype(sakId, it.name)))
-                } ?: ResponseEntity.status(HttpStatus.NOT_FOUND).body("Sakstype ikke funnet for sakId: $sakId")
+                    ResponseEntity.ok(FrontEndResponse(Pensjontype(sakId, it.name), HttpStatus.OK.name))
+                } ?: ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                    FrontEndResponse(result = null, status = HttpStatus.NOT_FOUND.name, message = "Sakstype ikke funnet for sakId: $sakId")
+                )
             } catch (e: Exception) {
                 logger.warn("Feil ved henting av sakstype på saksid: $sakId")
-                ResponseEntity.status(HttpStatus.BAD_REQUEST).body("")
+                ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                    FrontEndResponse(result = null, status = HttpStatus.BAD_REQUEST.name, message = "Feil ved henting av sakstype på saksid: $sakId")
+                )
             }
         }
     }
@@ -73,43 +75,58 @@ class PensjonController(
      * Brukes for å hente kravdato fra frontend / EP
      */
     @GetMapping("/kravdato/saker/{saksId}/krav/{kravId}/aktor/{aktoerId}")
-    fun hentKravDatoFraAktor(@PathVariable("saksId", required = true) sakId: String, @PathVariable("kravId", required = true) kravId: String, @PathVariable("aktoerId", required = true) aktoerId: String) : ResponseEntity<String>? {
+    fun hentKravDatoFraAktor(@PathVariable("saksId", required = true) sakId: String, @PathVariable("kravId", required = true) kravId: String, @PathVariable("aktoerId", required = true) aktoerId: String): ResponseEntity<FrontEndResponse<KravDato>> {
         return pensjonControllerKravDato.measure {
             val xid = MDC.get("x_request_id") ?: UUID.randomUUID().toString()
             if (sakId.isEmpty() || kravId.isEmpty() || aktoerId.isEmpty()) {
-                logger.warn("Det mangler verdier: saksId $sakId, kravId: $kravId, aktørId: $aktoerId")
-                return@measure ResponseEntity.status(HttpStatus.BAD_REQUEST).body("")
+                logger.warn("Det mangler verdier: saksId $sakId, kravId: $kravId, aktørId: $aktoerId, x_request_id: $xid")
+                return@measure ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                    FrontEndResponse(result = null, status = HttpStatus.BAD_REQUEST.name, message = "Det mangler verdier: saksId $sakId, kravId: $kravId, aktørId: $aktoerId")
+                )
             }
             return@measure try {
                 pesysService.hentKravdato(kravId)?.let {
-                    ResponseEntity.ok("""{ "kravDato": "$it" }""")
-                } ?: ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorBody("Feiler å hente kravDato", xid))
+                    ResponseEntity.ok(FrontEndResponse(KravDato(it.toString()), HttpStatus.OK.name))
+                } ?: ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                    FrontEndResponse(result = null, status = HttpStatus.BAD_REQUEST.name, message = "Feiler å hente kravDato")
+                )
             } catch (e: Exception) {
-                logger.warn("Feil ved henting av kravdato på saksid: $sakId", e)
-                ResponseEntity.status(HttpStatus.BAD_REQUEST).body("")
+                logger.warn("Feil ved henting av kravdato på saksid: $sakId, x_request_id: $xid", e)
+                ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                    FrontEndResponse(result = null, status = HttpStatus.BAD_REQUEST.name, message = "Feil ved henting av kravdato på saksid: $sakId")
+                )
             }
         }
     }
+
+    data class KravDato(
+        val kravDato: String
+    )
 
     /**
      * Brukes for å hente vedtak fra frontend / EP
      */
     @GetMapping("/vedtak/{vedtakid}/uforetidspunkt")
-    fun hentVedtakforForUfor(@PathVariable("vedtakid", required = true) vedtakId: String): String? {
+    fun hentVedtakforForUfor(@PathVariable("vedtakid", required = true) vedtakId: String): FrontEndResponse<Uforetidspunkt> {
         logger.info("Henter vedtak ($vedtakId)")
 
         val pensjonsinformasjon = pesysService.hentUfoeretidspunktOnVedtak(vedtakId).also {
             logger.debug("pensjonInfo: ${it?.toJsonSkipEmpty()}")
         }
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-        val resultatJson = mapOf(
-            "uforetidspunkt" to pensjonsinformasjon?.uforetidspunkt?.let { formatter.format(it) },
-            "virkningstidspunkt" to pensjonsinformasjon?.virkningstidspunkt?.let { formatter.format(it) }
-        ).toJson()
+        val uforetidspunkt = Uforetidspunkt(
+            uforetidspunkt = pensjonsinformasjon?.uforetidspunkt?.let { formatter.format(it) },
+            virkningstidspunkt = pensjonsinformasjon?.virkningstidspunkt?.let { formatter.format(it) }
+        )
 
-        logger.info("Oppslag på uføretidspunkt ga: $resultatJson")
-        return resultatJson
+        logger.info("Oppslag på uføretidspunkt ga: $uforetidspunkt")
+        return FrontEndResponse(uforetidspunkt, HttpStatus.OK.name)
     }
+
+    data class Uforetidspunkt(
+        val uforetidspunkt: String?,
+        val virkningstidspunkt: String?
+    )
 
     /**
      * Brukes for å henter sakliste for aktoer fra journalføring

--- a/src/test/kotlin/no/nav/eessi/pensjon/api/pensjon/PensjonControllerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/api/pensjon/PensjonControllerTest.kt
@@ -1,5 +1,6 @@
 package no.nav.eessi.pensjon.api.pensjon
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.SpyK
@@ -13,14 +14,14 @@ import no.nav.eessi.pensjon.personoppslag.pdl.model.NorskIdent
 import no.nav.eessi.pensjon.services.pensjonsinformasjon.EessiFellesDto
 import no.nav.eessi.pensjon.services.pensjonsinformasjon.EessiPensjonSak
 import no.nav.eessi.pensjon.services.pensjonsinformasjon.PesysService
-import no.nav.eessi.pensjon.utils.mapJsonToAny
 import no.nav.eessi.pensjon.utils.toJson
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import org.skyscreamer.jsonassert.JSONAssert
 import org.slf4j.MDC
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
@@ -55,12 +56,9 @@ class PensjonControllerTest {
     @Test
     fun `hentPensjonSakType gitt en aktoerId saa slaa opp fnr og hent deretter sakstype`() {
         every { pesysService.hentSaktype(SOME_SAKID) } returns SOME_SAK_TYPE
-        val result = controller.hentPensjonSakType(SOME_SAKID, AKTOERID)
-        JSONAssert.assertEquals(
-            """{
-              "sakId": "10000",
-              "sakType": "ALDER"
-        }""".trimIndent(), result?.body,true)
+        val response = controller.hentPensjonSakType(SOME_SAKID, AKTOERID)
+        assertEquals("OK", response.body?.status)
+        assertEquals(PensjonController.Pensjontype(SOME_SAKID, SOME_SAK_TYPE.name), response.body?.result)
     }
 
     @Test
@@ -68,7 +66,10 @@ class PensjonControllerTest {
 
         every { pesysService.hentSaktype(SOME_SAKID) } returns null
         val response = controller.hentPensjonSakType(SOME_SAKID, AKTOERID)
-        assertEquals("Sakstype ikke funnet for sakId: $SOME_SAKID", response?.body)
+        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+        assertNull(response.body?.result)
+        assertEquals("NOT_FOUND", response.body?.status)
+        assertEquals("Sakstype ikke funnet for sakId: $SOME_SAKID", response.body?.message)
     }
 
     private fun getExpectedKunSakType() = """
@@ -84,7 +85,10 @@ class PensjonControllerTest {
         val response = controller.hentPensjonSakType(SOME_SAKID, AKTOERID)
 
         verify { pesysService.hentSaktype(SOME_SAKID) }
-        assertEquals("Sakstype ikke funnet for sakId: $SOME_SAKID", response?.body)
+        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+        assertNull(response.body?.result)
+        assertEquals("NOT_FOUND", response.body?.status)
+        assertEquals("Sakstype ikke funnet for sakId: $SOME_SAKID", response.body?.message)
     }
 
     @Test
@@ -94,12 +98,8 @@ class PensjonControllerTest {
                     LocalDate.of(2021, 1, 1),
                     LocalDate.of(2021, 1, 31))
         val response = controller.hentVedtakforForUfor(SOME_SAKID)
-        assertEquals("""
-            {
-              "uforetidspunkt" : "2021-01-01",
-              "virkningstidspunkt" : "2021-01-31"
-            }
-        """.trimIndent(), response)
+        assertEquals("OK", response.status)
+        assertEquals(PensjonController.Uforetidspunkt("2021-01-01", "2021-01-31"), response.result)
     }
 
     @Test
@@ -146,7 +146,9 @@ class PensjonControllerTest {
             .andReturn()
 
         val response = result.response.getContentAsString(charset("UTF-8"))
-        assertEquals("""{ "kravDato": "$kravDato" }""", response)
+        val jsonNode = ObjectMapper().readTree(response)
+        assertEquals("OK", jsonNode.get("status").asText())
+        assertEquals(kravDato, jsonNode.get("result").get("kravDato").asText())
     }
 
     @Test
@@ -177,8 +179,11 @@ class PensjonControllerTest {
             )
             .andReturn()
         val response = result.response.getContentAsString(charset("UTF-8"))
+        val jsonNode = ObjectMapper().readTree(response)
 
-        assertEquals(dto, mapJsonToAny<EessiFellesDto.EessiUfoeretidspunktDto>(response))
+        assertEquals("OK", jsonNode.get("status").asText())
+        assertEquals(ufoereTidspunkt.toString(), jsonNode.get("result").get("uforetidspunkt").asText())
+        assertEquals(virkningsTidspunkts.toString(), jsonNode.get("result").get("virkningstidspunkt").asText())
     }
 
     @Test
@@ -188,10 +193,10 @@ class PensjonControllerTest {
 
         val response = controller.hentKravDatoFraAktor(SOME_SAKID, KRAV_ID, AKTOERID)
 
-        JSONAssert.assertEquals(
-            """{"success": false, "error": "Feiler å hente kravDato", "uuid": "AAA-BBB"}""",
-            response?.body, true
-        )
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertNull(response.body?.result)
+        assertEquals("BAD_REQUEST", response.body?.status)
+        assertEquals("Feiler å hente kravDato", response.body?.message)
     }
 
     @Test


### PR DESCRIPTION
Migrerer de tre frontend-vendte endepunktene i `PensjonController` til aa returnere `FrontEndResponse<T>`.

## Endringer
- `hentPensjonSakType` (`GET /pensjon/saktype/{sakId}/{aktoerId}`) -> `ResponseEntity<FrontEndResponse<Pensjontype>>` (200 / 404 / 400)
- `hentKravDatoFraAktor` (`GET /pensjon/kravdato/saker/{saksId}/krav/{kravId}/aktor/{aktoerId}`) -> `ResponseEntity<FrontEndResponse<KravDato>>` (ny `data class KravDato`)
- `hentVedtakforForUfor` (`GET /pensjon/vedtak/{vedtakid}/uforetidspunkt`) -> `FrontEndResponse<Uforetidspunkt>` (ny `data class Uforetidspunkt`)

`hentsakListeFraPesys` (`GET /pensjon/saklisteFraPesys`) er **uendret** - den er tjeneste-til-tjeneste (konsumeres av eessi-pensjon-journalforing og eessi-pensjon-dodsmelding), og wrapping ville brutt dem.

## Hvorfor beholde HTTP-statuskoder
De to feil-returnerende endepunktene beholder reelle HTTP-statuskoder (404/400) via `ResponseEntity`, fordi frontend (`@navikt/fetch`) trigger sin feil-action paa `response.status >= 400`. De er derfor ikke kollapset til plain `FrontEndResponse` med HTTP 200.

## Tester
`PensjonControllerTest` er oppdatert slik at alle assertions gaar mot den nye wrapperen (`result` / `status` / `message`). `hentsakListeFraPesys`-testen er uendret.

Verifisert med `./gradlew test --tests "*PensjonControllerTest*"` -> groent (11 tester, 1 skipped, 0 failures).

Closes #552